### PR TITLE
feat: SEO basics — OG, meta, sitemap, robots (closes #11)

### DIFF
--- a/app/blog/[slug]/opengraph-image.tsx
+++ b/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,118 @@
+import { ImageResponse } from 'next/og';
+
+import { getAllPosts, getPostBySlug } from '@/lib/posts';
+import { SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/*
+ * Per-post Open Graph image. Pulls the post title + date from the MDX
+ * frontmatter so each post page gets a card with its actual title rather
+ * than the generic site card. Falls back to the site card layout if the
+ * slug doesn't resolve (shouldn't happen — generateStaticParams gates it).
+ */
+export const alt = `${SITE_TITLE} — Blog`;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+// Pre-render one image per published post at build time. Without this,
+// Next.js would try to render the OG image on-demand at request time,
+// which is fine but means a cold-start latency on first social-card scrape.
+export async function generateImageMetadata() {
+  const posts = await getAllPosts();
+  return posts.map((post) => ({
+    id: post.slug,
+    alt: `${post.frontmatter.title} — ${SITE_TITLE}`,
+    size,
+    contentType,
+  }));
+}
+
+export default async function PostOpengraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getPostBySlug(slug);
+
+  const title = post?.frontmatter.title ?? SITE_TITLE;
+  const date = post?.frontmatter.date ?? '';
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '80px 96px',
+          background: '#0a0a0a',
+          color: '#f5f5f5',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            fontSize: 22,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#a3a3a3',
+            fontFamily: 'monospace',
+          }}
+        >
+          <span>{SITE_URL.replace(/^https?:\/\//, '')}/blog</span>
+          {date ? <span>{date}</span> : null}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 32,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 28,
+              letterSpacing: '0.18em',
+              textTransform: 'uppercase',
+              color: '#f97316',
+              fontFamily: 'monospace',
+              display: 'flex',
+            }}
+          >
+            Writing
+          </div>
+          <div
+            style={{
+              fontSize: title.length > 60 ? 60 : 72,
+              fontWeight: 600,
+              letterSpacing: '-0.025em',
+              lineHeight: 1.05,
+              maxWidth: 1000,
+              display: 'flex',
+            }}
+          >
+            {title}
+          </div>
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 28,
+            color: '#d4d4d4',
+            fontFamily: 'sans-serif',
+          }}
+        >
+          {SITE_TITLE}
+          <span style={{ color: '#f97316' }}>.</span>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { formatPostDate, getAllPosts, getPostBySlug } from '@/lib/posts';
+import { SITE_TITLE } from '@/lib/site';
 
 type Params = { slug: string };
 
@@ -19,14 +20,25 @@ export async function generateMetadata({
   const { slug } = await params;
   const post = await getPostBySlug(slug);
   if (!post) return {};
+  const canonical = `/blog/${slug}`;
   return {
     title: post.frontmatter.title,
     description: post.frontmatter.excerpt,
+    authors: [{ name: SITE_TITLE }],
+    alternates: { canonical },
     openGraph: {
       title: post.frontmatter.title,
       description: post.frontmatter.excerpt,
       type: 'article',
+      url: canonical,
       publishedTime: post.frontmatter.date,
+      authors: [SITE_TITLE],
+      tags: post.frontmatter.tags,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.frontmatter.title,
+      description: post.frontmatter.excerpt,
     },
   };
 }

--- a/app/blog/[slug]/twitter-image.tsx
+++ b/app/blog/[slug]/twitter-image.tsx
@@ -1,0 +1,12 @@
+/*
+ * Twitter card image for blog posts — reuses the per-post Open Graph image.
+ * Same renderer, same dimensions, separate file because Next.js looks them
+ * up by convention name.
+ */
+export {
+  default,
+  alt,
+  size,
+  contentType,
+  generateImageMetadata,
+} from './opengraph-image';

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -3,9 +3,24 @@ import Link from 'next/link';
 
 import { formatPostDate, getAllPosts } from '@/lib/posts';
 
+const BLOG_DESCRIPTION =
+  'Writing on software engineering — systems, ops, and the work of leading teams that ship.';
+
 export const metadata: Metadata = {
   title: 'Blog',
-  description: 'Writing on software engineering — systems, ops, and leadership.',
+  description: BLOG_DESCRIPTION,
+  alternates: { canonical: '/blog' },
+  openGraph: {
+    title: 'Blog — Matt Sears',
+    description: BLOG_DESCRIPTION,
+    url: '/blog',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Blog — Matt Sears',
+    description: BLOG_DESCRIPTION,
+  },
 };
 
 export default async function BlogIndexPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css';
 import { ThemeScript } from './components/theme-script';
 import { SiteHeader } from './components/site-header';
 import { SiteFooter } from './components/site-footer';
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/site';
 
 /*
  * Font setup — see docs/design.md for the role table.
@@ -34,13 +35,56 @@ const mono = JetBrains_Mono({
   variable: '--font-mono',
 });
 
+/*
+ * Site-wide metadata. Per-route files override the title/description and
+ * provide route-specific openGraph/twitter overrides; everything else
+ * (metadataBase, siteName, default OG image via convention) is inherited.
+ *
+ * The OG/Twitter images are picked up by Next.js automatically from the
+ * `app/opengraph-image.tsx` / `app/twitter-image.tsx` route files (and any
+ * matching files in nested route segments). We do NOT enumerate them here.
+ */
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
-    default: 'Matt Sears',
-    template: '%s — Matt Sears',
+    default: SITE_TITLE,
+    template: `%s — ${SITE_TITLE}`,
   },
-  description:
-    'Matt Sears — senior software engineer. Personal site, work, and writing.',
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_TITLE,
+  authors: [{ name: SITE_TITLE, url: SITE_URL }],
+  creator: SITE_TITLE,
+  publisher: SITE_TITLE,
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
+  },
+  alternates: {
+    canonical: '/',
+    types: {
+      'application/rss+xml': [{ url: '/rss.xml', title: `${SITE_TITLE} — RSS` }],
+    },
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: SITE_URL,
+    siteName: SITE_TITLE,
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,0 +1,84 @@
+import { ImageResponse } from 'next/og';
+
+import { SITE_TAGLINE, SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/*
+ * Site-wide Open Graph image (1200×630). Renders at build time via Next's
+ * `next/og` ImageResponse — no static asset required. Routes that want a
+ * custom image (e.g. blog post pages) ship their own `opengraph-image.tsx`
+ * in the matching route segment, which overrides this one for that route.
+ *
+ * Design language matches the landing hero: dark background, sans display
+ * type with a trailing accent period. We don't pull in the site's color
+ * tokens via Tailwind here because ImageResponse renders in a sandboxed
+ * Satori environment that doesn't see the Tailwind layer.
+ */
+export const alt = `${SITE_TITLE} — ${SITE_TAGLINE}`;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '80px 96px',
+          background: '#0a0a0a',
+          color: '#f5f5f5',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 22,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#a3a3a3',
+            fontFamily: 'monospace',
+          }}
+        >
+          {SITE_URL.replace(/^https?:\/\//, '')}
+        </div>
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 24,
+          }}
+        >
+          <div
+            style={{
+              fontSize: 84,
+              fontWeight: 600,
+              letterSpacing: '-0.03em',
+              lineHeight: 1,
+              display: 'flex',
+            }}
+          >
+            {SITE_TITLE}
+            <span style={{ color: '#f97316' }}>.</span>
+          </div>
+          <div
+            style={{
+              fontSize: 36,
+              color: '#d4d4d4',
+              lineHeight: 1.25,
+              maxWidth: 880,
+              display: 'flex',
+            }}
+          >
+            {SITE_TAGLINE}
+          </div>
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,31 @@
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
+import { SITE_TAGLINE, SITE_TITLE } from '@/lib/site';
+
+/*
+ * Landing page metadata. Uses `title.absolute` to override the layout's
+ * `%s — Matt Sears` template (would otherwise produce "Matt Sears — Matt
+ * Sears" since the layout default is the bare site title). Description is
+ * the hero tagline — more concrete than the layout-level fallback.
+ */
+export const metadata: Metadata = {
+  title: { absolute: SITE_TITLE },
+  description: SITE_TAGLINE,
+  alternates: { canonical: '/' },
+  openGraph: {
+    title: SITE_TITLE,
+    description: SITE_TAGLINE,
+    url: '/',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: SITE_TITLE,
+    description: SITE_TAGLINE,
+  },
+};
 
 /**
  * Landing page — hero + brief about. Build slice #8.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next';
+
+import { SITE_URL } from '@/lib/site';
+
+/*
+ * `/robots.txt` — emitted by Next from this file at build time.
+ *
+ * Allow-all policy with a pointer to the sitemap. We aren't disallowing
+ * anything because there's nothing on the site that shouldn't be indexed —
+ * if a private route ever lands, list it under `disallow` here.
+ */
+export const dynamic = 'force-static';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from 'next';
+
+import { getAllPosts } from '@/lib/posts';
+import { SITE_URL } from '@/lib/site';
+
+/*
+ * `/sitemap.xml` — emitted by Next from this file at build time.
+ *
+ * Includes:
+ *   - `/`        landing page                     (changeFrequency: monthly)
+ *   - `/blog`    blog index                       (changeFrequency: weekly)
+ *   - `/blog/:slug` every published post          (lastModified = frontmatter date)
+ *
+ * `/work` is intentionally absent — the route doesn't exist yet (issue #9).
+ * Add it here when that slice ships.
+ */
+export const dynamic = 'force-static';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPosts();
+  const now = new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: `${SITE_URL}/`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 1.0,
+    },
+    {
+      url: `${SITE_URL}/blog`,
+      lastModified: posts[0] ? new Date(`${posts[0].frontmatter.date}T00:00:00Z`) : now,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${SITE_URL}/blog/${post.slug}`,
+    lastModified: new Date(`${post.frontmatter.date}T00:00:00Z`),
+    changeFrequency: 'yearly',
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,0 +1,5 @@
+/*
+ * Twitter card image — reuses the Open Graph image renderer. Next.js
+ * requires a separate file rather than letting us alias one to the other.
+ */
+export { default, alt, size, contentType } from './opengraph-image';

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -1,0 +1,10 @@
+/**
+ * Site-wide constants. Keep the source of truth in one place so metadata,
+ * sitemap, robots, and feed generators all agree on the canonical URL and
+ * branding strings.
+ */
+export const SITE_URL = 'https://mattsears18.com';
+export const SITE_TITLE = 'Matt Sears';
+export const SITE_DESCRIPTION =
+  'Matt Sears — senior software engineer. Notes on engineering practice, systems, and the work of leading teams that ship.';
+export const SITE_TAGLINE = 'Senior software engineer who ships reliable systems.';

--- a/next.config.js
+++ b/next.config.js
@@ -11,6 +11,12 @@ const rehypePrettyCodeOptions = {
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
+  // Pin the workspace root so Turbopack doesn't latch onto a stray
+  // lockfile higher up the tree (happens when the repo is checked out
+  // under a home directory that has its own yarn.lock / package-lock.json).
+  turbopack: {
+    root: __dirname,
+  },
 };
 
 const withMDX = createMDX({


### PR DESCRIPTION
## Summary

Adds the site-wide SEO surface (Closes #11):

- **Site-wide metadata defaults** hoisted to `app/layout.tsx` — `metadataBase`, title template, description, default `openGraph` + `twitter` cards, robots policy, canonical, RSS alternate. Per-route files override only the bits that differ.
- **Per-route metadata** on `/`, `/blog`, `/blog/[slug]` with route-specific canonical, OG URL, twitter card config. Per-post pages set `og:type=article` + `publishedTime` + author/tags.
- **Dynamic OG + Twitter card images** via `next/og` `ImageResponse`:
  - `app/opengraph-image.tsx` + `app/twitter-image.tsx` — site-wide 1200×630 card (dark BG, "Matt Sears." display type + tagline).
  - `app/blog/[slug]/opengraph-image.tsx` + `twitter-image.tsx` — per-post card driven by `generateImageMetadata`, one pre-rendered PNG per published post.
  - All static-prerendered at build time; no edge runtime needed.
- **`/sitemap.xml`** via `app/sitemap.ts` — covers `/`, `/blog`, every published post under `content/posts/`. `lastModified` per-post comes from the MDX frontmatter date.
- **`/robots.txt`** via `app/robots.ts` — allow-all, points at the sitemap.
- **`lib/site.ts`** — shared `SITE_URL` / `SITE_TITLE` / `SITE_DESCRIPTION` / `SITE_TAGLINE` so metadata, sitemap, robots, and OG renderers all agree.
- **`next.config.js`** — pins `turbopack.root` to the worktree dir so the build doesn't latch onto a stray lockfile higher up the directory tree.

## Out of scope

- **Portfolio page metadata** — `/work` doesn't exist yet ([#9](https://github.com/mattsears18/mattsears18.com/issues/9) is blocked). Add it to the sitemap + give it a route-specific OG when that slice ships.
- **Analytics** — issue marked it optional; deferring to a follow-up issue if you ever want Plausible / Vercel Analytics. Skipping keeps this PR focused on the hard requirements.

## Production deploy

Vercel auto-deploys `main` on merge (saw it fire on #16). The "production deploy" acceptance criterion is satisfied by getting this PR merged; custom-domain verification happens post-merge.

## Test plan

- [x] `npm run build` — clean, TS green, all SEO routes static-prerendered (`/sitemap.xml`, `/robots.txt`, `/opengraph-image`, `/twitter-image`, `/blog/[slug]/opengraph-image/[__metadata_id__]`).
- [x] Landing HTML (`/`) — view-source shows `<title>`, `description`, `canonical`, `og:title/description/url/image/type=website`, `twitter:card=summary_large_image` etc.
- [x] Blog index HTML (`/blog`) — same set, with route-specific overrides.
- [x] Blog post HTML (`/blog/hello-from-the-new-site`) — per-post `og:title`, `og:type=article`, `og:publishedTime`, per-post `og:image` URL.
- [x] Generated OG image is a real 1200×630 PNG (~40KB).
- [x] `/sitemap.xml` lists `/`, `/blog`, and the post; valid XML.
- [x] `/robots.txt` — allow-all, sitemap pointer.
- [ ] Post-merge: `https://mattsears18.com/sitemap.xml` and `/robots.txt` load on the production domain (verified after Vercel deploy lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)