### PR TITLE
content: portfolio shortlist — 6 project MDX files (closes #7)

### DIFF
--- a/content/work/cdot-duration-predictor.mdx
+++ b/content/work/cdot-duration-predictor.mdx
@@ -1,0 +1,17 @@
+---
+title: 'CDOT Construction Duration Predictor'
+role: 'PhD Researcher'
+year: '2015–2018'
+summary: 'Neural network that predicts highway construction durations for the Colorado DOT — packaged as a web app now used statewide.'
+tech: ['Keras', 'TensorFlow', 'Python', 'Django']
+links:
+  external: 'https://pmodev.codot.gov/contracttimes'
+  paper: 'https://pooledfund.org/details/study/489'
+featured: true
+---
+
+Built an artificial neural network for the [Colorado Department of Transportation](https://www.codot.gov/) to predict construction duration for highway projects based on estimated material quantities and geographic attributes.
+
+The ANN proved substantially faster and more reliable than CDOT's existing methods, and significantly more accurate than the linear regression models other academic institutions had developed.
+
+CDOT was pleased enough with the results to commission a [web app](https://pmodev.codot.gov/contracttimes) wrapping the model — now used by civil engineers across the state on every CDOT project. Funded by Transportation Pooled Fund [TPF-5(260)](https://pooledfund.org/details/study/489); other state DOTs in the study group later asked us to extend the model to their states.

--- a/content/work/express-delphi.mdx
+++ b/content/work/express-delphi.mdx
@@ -1,0 +1,18 @@
+---
+title: 'Express Delphi'
+role: 'PhD Researcher'
+year: '2017–2018'
+summary: 'Web app for running the Delphi Method — group decision-making, 50× faster than the traditional process.'
+tech: ['React', 'Meteor', 'MongoDB', 'Heroku', 'Plotly', 'jStat']
+links:
+  external: 'https://www.youtube.com/watch?v=pIQxhofsJeo'
+  github: 'https://github.com/mattsears18/express-delphi-meteor'
+  video: 'https://www.youtube.com/watch?v=gEY-Hcdg7vc&t=851s'
+featured: false
+---
+
+A web app for running [the Delphi Method](https://www.researchgate.net/publication/255488148_Qualitative_Research_Application_of_the_Delphi_Method_to_CEM_Research) — a structured group decision-making process — about 50× faster than the conventional paper-driven workflow.
+
+Built with my PhD advisor [Dr. Paul Goodrum](https://www.chhs.colostate.edu/bio-page/paul-goodrum-6020/) for [Research Team DCC-01](https://www.construction-institute.org/resources/knowledgebase/10-10-metrics/result/topics/rt-dcc-01) to rank-order potential research topics for improving construction productivity.
+
+We used the app live in an in-person session with 30 subject matter experts, and the ranked output formed the foundation of [our team's publication](https://www.construction-institute.org/resources/knowledgebase/10-10-metrics/result/topics/rt-dcc-01).

--- a/content/work/lightwork.mdx
+++ b/content/work/lightwork.mdx
@@ -1,0 +1,16 @@
+---
+title: 'Lightwork'
+role: 'Creator'
+year: '2024–present'
+summary: 'A volunteer task management app — groups post tasks that need help, members sign up to do them. Built with Expo + Firebase.'
+tech: ['Expo', 'React Native', 'Expo Router', 'Firebase', 'Firestore', 'Algolia', 'TypeScript']
+links:
+  external: 'https://lightwork-gray.vercel.app'
+featured: true
+---
+
+[Lightwork](https://lightwork-gray.vercel.app) is a volunteer task management app for groups that organize collective work. Members join groups, post tasks that need volunteers, and sign up to help — with real-time updates powered by Firestore.
+
+Universal across iOS, Android, and web from a single Expo codebase. Shipping a mobile app solo means owning every layer: native config plugins, EAS build pipelines, OTA vs. store-release gating, App Store and Play Console submissions, privacy manifests, deep links, push notifications, and an emulator-backed test suite that runs the same Firestore rules CI runs against.
+
+105 integration + rules tests against the Firebase emulator, Playwright web E2E, and Maestro mobile E2E — all in the standard pre-push loop.

--- a/content/work/nccer-sso.mdx
+++ b/content/work/nccer-sso.mdx
@@ -1,0 +1,16 @@
+---
+title: 'NCCER Single Sign-On'
+role: 'Software Engineer'
+year: '2019–2020'
+summary: 'Architected and shipped NCCER\'s most-requested feature — SSO across all customer-facing services.'
+tech: ['Node.js', 'OAuth 2.0', 'OpenID Connect', 'AWS']
+links:
+  external: 'https://web.account.nccer.org'
+featured: true
+---
+
+When I joined [NCCER](https://www.nccer.org) in 2019, [Single Sign-On](https://web.account.nccer.org) was the single most-requested feature from customers.
+
+I evaluated implementation options, designed the architecture, wrote the documentation, built the backend service end-to-end, and coordinated with half a dozen third-party developers to integrate every existing NCCER service against it. Built internal dashboards to track user migration in real time and worked with the customer support team on rollout.
+
+Also served as the "technical translator" for executive decision-making throughout — turning architecture trade-offs into language the leadership team could act on.

--- a/content/work/shipyard.mdx
+++ b/content/work/shipyard.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Shipyard'
+role: 'Creator'
+year: '2026–present'
+summary: 'An autonomous engineering loop — a Claude Code plugin that finds, refines, and ships work from a GitHub backlog without per-step human approval.'
+tech: ['Claude Code', 'Bash', 'GitHub Actions', 'jq', 'gh CLI']
+links:
+  external: 'https://github.com/mattsears18/shipyard'
+  github: 'https://github.com/mattsears18/shipyard'
+featured: true
+---
+
+[Shipyard](https://github.com/mattsears18/shipyard) is an experimental [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin that runs an autonomous engineering loop. It finds work (deep audits across UX, performance, security, a11y, SEO, privacy, dev experience, tech debt, and more — each finding becomes a GitHub issue), refines raw user feedback into actionable tickets, and burns down the backlog with a rolling pool of parallel workers in isolated git worktrees.
+
+The orchestrator dispatches up to `--concurrency` workers at once, opens PRs that close their assigned issues, arms auto-merge, and gracefully handles failing CI, red main, and PR pileups via specialized diversion workers.
+
+Shipyard is built with shipyard — the majority of merged PRs in the repo were opened by `/do-work` workers, fixed up through CI failures, and merged without a human touching the keyboard between issue triage and PR review. This portfolio site is also built with it.

--- a/content/work/visual-eyes.mdx
+++ b/content/work/visual-eyes.mdx
@@ -1,0 +1,16 @@
+---
+title: 'VisualEyes'
+role: 'PhD Researcher'
+year: '2018–2020'
+summary: 'Eye-tracking analysis app that became the foundation of my PhD dissertation and five published papers.'
+tech: ['React', 'Meteor', 'MongoDB', 'Vercel', 'Plotly', 'jStat']
+links:
+  external: 'https://www.youtube.com/watch?v=Ed6oByh5tJw'
+  github: 'https://github.com/mattsears18/visual-eyes'
+  paper: 'https://www.researchgate.net/publication/343178511_Advanced_Eye_Tracking_Analysis_for_Investigating_Construction_Craft_Professional_Interactions_with_2D_Drawings'
+featured: true
+---
+
+A web app for visualizing and analyzing eye-tracking data from the dominant commercial hardware vendors.
+
+This was the foundation of [my PhD dissertation](https://www.researchgate.net/publication/343178511_Advanced_Eye_Tracking_Analysis_for_Investigating_Construction_Craft_Professional_Interactions_with_2D_Drawings) and [five other publications](https://www.researchgate.net/profile/Matt-Sears/research). It included a [custom video player](https://www.youtube.com/watch?v=Ed6oByh5tJw) built from scratch, [an npm package](https://www.npmjs.com/package/time-hulls) for analyzing timestamped 2D point data, data cleansing and processing services, and dozens of computed metrics and visualizations exportable for further analysis.


### PR DESCRIPTION
## Summary

Captures the project shortlist called for in #7. Six MDX entries under `content/work/` — schema agreed in brainstorming (`title`, `role`, `year`, `summary`, `tech`, `links`, `featured`).

- **cdot-duration-predictor** — Colorado DOT neural-net duration model (PhD-era)
- **express-delphi** — Delphi Method web app (PhD-era)
- **nccer-sso** — NCCER Single Sign-On rollout
- **visual-eyes** — eye-tracking analysis app (PhD dissertation foundation)
- **shipyard** — autonomous engineering loop (Claude Code plugin)
- **lightwork** — Expo + Firebase volunteer task app

The first four are revived (with light copy edits) from the previous Gatsby site's `content/featured/` directory; shipyard and lightwork are new.

## Scope notes

- **Content only.** The `/work` route, index page, and per-project detail pages are #9's scope, which was explicitly blocked on this issue.
- **No loader.** `lib/work.ts` (parallel to `lib/posts.ts`) belongs to #9 — held back to keep this PR tightly scoped to #7.
- **Best-guess metadata.** Years and roles for the four PhD-era/NCCER entries are inferred from the source material; flag anything that's wrong and I'll correct in a follow-up.

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally — content files are inert without a loader).
- [ ] Each entry's `external` / `github` / `paper` / `video` link resolves.
- [ ] `year`, `role`, and `tech` fields match your recall.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)