### PR TITLE
feat: /work portfolio index + per-project detail pages (closes #9)

### DIFF
--- a/app/components/site-header.tsx
+++ b/app/components/site-header.tsx
@@ -4,9 +4,10 @@ import { ThemeToggle } from './theme-toggle';
 
 /**
  * Top-of-page header. Minimal by design: name on the left as a home link,
- * theme toggle on the right. Nav links land in #10 / #9 when the /blog and
- * /work routes exist — adding them here while they 404 would be a worse
- * signal than omitting them.
+ * primary nav (Work, Blog) in the middle/right, theme toggle on the far
+ * right. Nav was held back until both routes existed (#10 added /blog,
+ * #9 added /work) — adding them earlier would have been a worse signal
+ * than omitting them.
  */
 export function SiteHeader() {
   return (
@@ -18,7 +19,21 @@ export function SiteHeader() {
         >
           Matt Sears
         </Link>
-        <ThemeToggle />
+        <nav aria-label="Primary" className="flex items-center gap-1 sm:gap-2">
+          <Link
+            href="/work"
+            className="rounded-md px-3 py-2 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          >
+            Work
+          </Link>
+          <Link
+            href="/blog"
+            className="rounded-md px-3 py-2 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          >
+            Blog
+          </Link>
+          <ThemeToggle />
+        </nav>
       </div>
     </header>
   );

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,22 +2,27 @@ import type { MetadataRoute } from 'next';
 
 import { getAllPosts } from '@/lib/posts';
 import { SITE_URL } from '@/lib/site';
+import { getAllProjects } from '@/lib/work';
 
 /*
  * `/sitemap.xml` — emitted by Next from this file at build time.
  *
  * Includes:
- *   - `/`        landing page                     (changeFrequency: monthly)
- *   - `/blog`    blog index                       (changeFrequency: weekly)
- *   - `/blog/:slug` every published post          (lastModified = frontmatter date)
+ *   - `/`             landing page              (changeFrequency: monthly)
+ *   - `/blog`         blog index                (changeFrequency: weekly)
+ *   - `/blog/:slug`   every published post      (lastModified = frontmatter date)
+ *   - `/work`         portfolio index           (changeFrequency: monthly)
+ *   - `/work/:slug`   every project detail page (changeFrequency: yearly)
  *
- * `/work` is intentionally absent — the route doesn't exist yet (issue #9).
- * Add it here when that slice ships.
+ * Project frontmatter has no `date` field — projects are evergreen — so we
+ * use `now` for project lastModified. Acceptable: search engines mostly use
+ * this for crawl scheduling, not freshness ranking, and the project pages
+ * change infrequently.
  */
 export const dynamic = 'force-static';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const posts = await getAllPosts();
+  const [posts, projects] = await Promise.all([getAllPosts(), getAllProjects()]);
   const now = new Date();
 
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -33,6 +38,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    {
+      url: `${SITE_URL}/work`,
+      lastModified: now,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
   ];
 
   const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
@@ -42,5 +53,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticRoutes, ...postRoutes];
+  const projectRoutes: MetadataRoute.Sitemap = projects.map((project) => ({
+    url: `${SITE_URL}/work/${project.slug}`,
+    lastModified: now,
+    changeFrequency: 'yearly',
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...postRoutes, ...projectRoutes];
 }

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { formatLinkLabel, getAllProjects, getProjectBySlug } from '@/lib/work';
+import { SITE_TITLE } from '@/lib/site';
+
+type Params = { slug: string };
+
+export async function generateStaticParams(): Promise<Params[]> {
+  const projects = await getAllProjects();
+  return projects.map((p) => ({ slug: p.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<Params>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+  if (!project) return {};
+  const canonical = `/work/${slug}`;
+  return {
+    title: project.frontmatter.title,
+    description: project.frontmatter.summary,
+    authors: [{ name: SITE_TITLE }],
+    alternates: { canonical },
+    openGraph: {
+      title: project.frontmatter.title,
+      description: project.frontmatter.summary,
+      type: 'article',
+      url: canonical,
+      authors: [SITE_TITLE],
+      tags: project.frontmatter.tech,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: project.frontmatter.title,
+      description: project.frontmatter.summary,
+    },
+  };
+}
+
+/**
+ * `/work/<slug>` — project detail page.
+ *
+ * Mirrors the blog post layout (max-w-reading, generous vertical rhythm)
+ * because design.md calls for blog typography on the top 1–2 case studies —
+ * we apply it uniformly so every project gets the same reading treatment.
+ *
+ * MDX body is dynamically imported from `content/work/<slug>.mdx`; the
+ * `generateStaticParams` enumeration ensures every slug renders at build
+ * time, which keeps the import path statically analyzable.
+ */
+export default async function ProjectPage({
+  params,
+}: {
+  params: Promise<Params>;
+}) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+  if (!project) notFound();
+
+  const { default: MDXContent } = await import(`@/content/work/${slug}.mdx`);
+  const links = project.frontmatter.links ?? {};
+
+  return (
+    <article className="mx-auto max-w-reading py-12 sm:py-16">
+      <nav className="mb-10">
+        <Link
+          href="/work"
+          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+        >
+          ← Back to work
+        </Link>
+      </nav>
+
+      <header className="mb-10 sm:mb-12">
+        <p className="mb-4 font-mono text-xs uppercase tracking-widest text-fg-muted">
+          <span>{project.frontmatter.role}</span>
+          <span aria-hidden="true"> · </span>
+          <span>{project.frontmatter.year}</span>
+        </p>
+        <h1 className="font-display text-4xl font-medium tracking-tight text-fg sm:text-5xl lg:text-display-sm">
+          {project.frontmatter.title}
+        </h1>
+        <p className="mt-5 text-lg leading-relaxed text-fg-muted">
+          {project.frontmatter.summary}
+        </p>
+
+        <ul
+          aria-label="Technology stack"
+          className="mt-6 flex flex-wrap gap-2"
+        >
+          {project.frontmatter.tech.map((tech) => (
+            <li
+              key={tech}
+              className="rounded border border-border px-2 py-1 font-mono text-xs text-fg-muted"
+            >
+              {tech}
+            </li>
+          ))}
+        </ul>
+
+        {Object.keys(links).length > 0 ? (
+          <p className="mt-6 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs uppercase tracking-widest">
+            {Object.entries(links).map(([key, href]) => (
+              <a
+                key={key}
+                href={href}
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent underline-offset-4 hover:underline"
+              >
+                {formatLinkLabel(key)} ↗
+              </a>
+            ))}
+          </p>
+        ) : null}
+      </header>
+
+      <div className="prose-post space-y-6 text-base leading-relaxed text-fg sm:text-lg [&_a]:text-accent [&_a]:underline-offset-4 hover:[&_a]:underline">
+        <MDXContent />
+      </div>
+
+      <footer className="mt-20 border-t border-border pt-8">
+        <Link
+          href="/work"
+          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+        >
+          All work →
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { formatLinkLabel, getAllProjects } from '@/lib/work';
+
+const WORK_DESCRIPTION =
+  'Selected projects — shipped systems, research tools, and side projects across a decade of building.';
+
+export const metadata: Metadata = {
+  title: 'Work',
+  description: WORK_DESCRIPTION,
+  alternates: { canonical: '/work' },
+  openGraph: {
+    title: 'Work — Matt Sears',
+    description: WORK_DESCRIPTION,
+    url: '/work',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Work — Matt Sears',
+    description: WORK_DESCRIPTION,
+  },
+};
+
+/**
+ * `/work` — portfolio index.
+ *
+ * Layout follows design.md §Work: list-style index, each project = title +
+ * 1-line role + 2–3 stack badges + summary. Featured projects lead (see
+ * `getAllProjects` sort order); within each tier sort is by recency.
+ *
+ * Every card links to its detail page at `/work/<slug>` — case-study depth
+ * is the MDX body, rendered by `app/work/[slug]/page.tsx`.
+ *
+ * `links` from frontmatter render as a small row of secondary actions on
+ * the card so a visitor can hop directly to the live site / repo / paper
+ * without an extra click through the detail page.
+ */
+export default async function WorkIndexPage() {
+  const projects = await getAllProjects();
+
+  return (
+    <div className="py-16 sm:py-20">
+      <header className="mb-12 max-w-reading sm:mb-16">
+        <p className="mb-4 font-mono text-xs uppercase tracking-widest text-fg-muted">
+          Selected work
+        </p>
+        <h1 className="font-display text-4xl font-medium tracking-tight text-fg sm:text-5xl">
+          Work
+        </h1>
+        <p className="mt-4 text-base leading-relaxed text-fg-muted">
+          A shortlist of projects from research, industry, and the side-project
+          shelf — chosen for breadth of stack and depth of outcome, not for
+          completeness.
+        </p>
+      </header>
+
+      {projects.length === 0 ? (
+        <p className="text-fg-muted">
+          Nothing here yet.{' '}
+          <Link href="/" className="text-accent underline-offset-4 hover:underline">
+            Back home →
+          </Link>
+        </p>
+      ) : (
+        <ul className="divide-y divide-border border-t border-border">
+          {projects.map((project) => {
+            const { slug, frontmatter } = project;
+            const links = frontmatter.links ?? {};
+            return (
+              <li key={slug} className="py-10 sm:py-12">
+                <article className="grid gap-6 sm:grid-cols-[1fr_2fr] sm:gap-10">
+                  <div className="space-y-2">
+                    <p className="font-mono text-xs uppercase tracking-widest text-fg-muted">
+                      <span>{frontmatter.role}</span>
+                      <span aria-hidden="true"> · </span>
+                      <span>{frontmatter.year}</span>
+                    </p>
+                  </div>
+
+                  <div className="max-w-reading">
+                    <h2 className="font-display text-2xl font-medium tracking-tight text-fg sm:text-3xl">
+                      <Link
+                        href={`/work/${slug}`}
+                        className="group inline-flex items-baseline gap-2 hover:text-accent"
+                      >
+                        <span>{frontmatter.title}</span>
+                        <span
+                          aria-hidden="true"
+                          className="text-base text-fg-muted transition-transform group-hover:translate-x-0.5 group-hover:text-accent"
+                        >
+                          →
+                        </span>
+                      </Link>
+                    </h2>
+
+                    <p className="mt-3 text-base leading-relaxed text-fg-muted">
+                      {frontmatter.summary}
+                    </p>
+
+                    <ul
+                      aria-label="Technology stack"
+                      className="mt-5 flex flex-wrap gap-2"
+                    >
+                      {frontmatter.tech.map((tech) => (
+                        <li
+                          key={tech}
+                          className="rounded border border-border px-2 py-1 font-mono text-xs text-fg-muted"
+                        >
+                          {tech}
+                        </li>
+                      ))}
+                    </ul>
+
+                    {Object.keys(links).length > 0 ? (
+                      <p className="mt-5 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs uppercase tracking-widest">
+                        {Object.entries(links).map(([key, href]) => (
+                          <a
+                            key={key}
+                            href={href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="text-accent underline-offset-4 hover:underline"
+                          >
+                            {formatLinkLabel(key)} ↗
+                          </a>
+                        ))}
+                      </p>
+                    ) : null}
+                  </div>
+                </article>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/content/work/nccer-sso.mdx
+++ b/content/work/nccer-sso.mdx
@@ -2,7 +2,7 @@
 title: 'NCCER Single Sign-On'
 role: 'Software Engineer'
 year: '2019–2020'
-summary: 'Architected and shipped NCCER\'s most-requested feature — SSO across all customer-facing services.'
+summary: "Architected and shipped NCCER's most-requested feature — SSO across all customer-facing services."
 tech: ['Node.js', 'OAuth 2.0', 'OpenID Connect', 'AWS']
 links:
   external: 'https://web.account.nccer.org'

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -1,0 +1,119 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import matter from 'gray-matter';
+
+/**
+ * Frontmatter shape for `content/work/*.mdx` projects.
+ *
+ * Required: title, role, year, summary, tech.
+ * Optional: links (external/repo/paper/video — open set), featured (boolean).
+ *
+ * `links` is intentionally a loose record so MDX authors can add new keys
+ * (paper / video / case-study) without re-touching this type — the index +
+ * detail pages render whatever keys are present using `formatLinkLabel`.
+ */
+export type ProjectLinks = Record<string, string>;
+
+export type ProjectFrontmatter = {
+  title: string;
+  role: string;
+  year: string;
+  summary: string;
+  tech: string[];
+  links?: ProjectLinks;
+  featured?: boolean;
+};
+
+export type Project = {
+  slug: string;
+  frontmatter: ProjectFrontmatter;
+  content: string;
+};
+
+const WORK_DIR = path.join(process.cwd(), 'content', 'work');
+
+async function readProjectFile(filename: string): Promise<Project | null> {
+  if (!filename.endsWith('.mdx')) return null;
+  const slug = filename.replace(/\.mdx$/, '');
+  const raw = await fs.readFile(path.join(WORK_DIR, filename), 'utf8');
+  const { data, content } = matter(raw);
+  const frontmatter = data as ProjectFrontmatter;
+  if (
+    !frontmatter.title ||
+    !frontmatter.role ||
+    !frontmatter.year ||
+    !frontmatter.summary ||
+    !Array.isArray(frontmatter.tech) ||
+    frontmatter.tech.length === 0
+  ) {
+    throw new Error(
+      `Project ${slug} is missing required frontmatter (title, role, year, summary, tech[])`,
+    );
+  }
+  return { slug, frontmatter, content };
+}
+
+/**
+ * Year-sort key. Frontmatter `year` is human-readable ("2024–present",
+ * "2015–2018", "2019–2020") — we sort newest-first by the trailing year of
+ * the range, treating "present" as the current year so active projects
+ * always lead. Ties broken by title to keep the order stable.
+ */
+function yearSortKey(year: string): number {
+  const parts = year.split(/[–-]/).map((p) => p.trim().toLowerCase());
+  const tail = parts[parts.length - 1];
+  if (tail === 'present') return new Date().getUTCFullYear();
+  const n = Number.parseInt(tail, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export async function getAllProjects(): Promise<Project[]> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(WORK_DIR);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const projects = await Promise.all(entries.map(readProjectFile));
+  return projects
+    .filter((p): p is Project => p !== null)
+    .sort((a, b) => {
+      // Featured first, then most-recent end-year, then title.
+      const featDelta = Number(b.frontmatter.featured ?? false) - Number(a.frontmatter.featured ?? false);
+      if (featDelta !== 0) return featDelta;
+      const yearDelta = yearSortKey(b.frontmatter.year) - yearSortKey(a.frontmatter.year);
+      if (yearDelta !== 0) return yearDelta;
+      return a.frontmatter.title.localeCompare(b.frontmatter.title);
+    });
+}
+
+export async function getProjectBySlug(slug: string): Promise<Project | null> {
+  try {
+    return await readProjectFile(`${slug}.mdx`);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+/**
+ * Render-friendly label for arbitrary `links` keys. Maps known keys to nicer
+ * labels; falls back to title-case for unknown keys so new link types ("demo",
+ * "case-study") render reasonably without a code change.
+ */
+export function formatLinkLabel(key: string): string {
+  const known: Record<string, string> = {
+    external: 'Visit',
+    repo: 'Repository',
+    github: 'GitHub',
+    paper: 'Paper',
+    video: 'Video',
+    demo: 'Demo',
+  };
+  if (known[key]) return known[key];
+  return key
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}


### PR DESCRIPTION
Closes #9

## Summary

- Adds `/work` portfolio index — list-style, featured projects lead, then most-recent end-year. Each row: title link, role + year, 2–3 stack badges, one-line summary, optional external/repo/paper/video shortcuts.
- Adds `/work/[slug]` per-project detail pages — case-study depth via dynamic MDX import + `generateStaticParams`, all 6 projects SSG at build time.
- Adds `lib/work.ts` (mirrors `lib/posts.ts`) — reads `content/work/*.mdx`, validates required frontmatter (`title`, `role`, `year`, `summary`, `tech[]`), and surfaces `formatLinkLabel` for the open-set `links` record.
- Updates `app/sitemap.ts` to include `/work` and every project detail page.
- Updates `app/components/site-header.tsx` with the primary nav (Work, Blog) — both routes now exist, so the held-back nav lands.
- Drive-by fix: `content/work/nccer-sso.mdx` had an invalid YAML single-quote escape (`'NCCER\'s'`) that prevented `gray-matter` from parsing the file. Switched the line to double-quoted; build now picks it up cleanly.

Design follows `docs/design.md` §Work: editorial list style, hairline borders, blog typography on detail pages, accent-colored secondary links.

## Test plan

- [x] `next build` — completes cleanly, all 6 `/work/<slug>` routes prerender as SSG.
- [x] `/work` index renders 6 projects, featured (lightwork, cdot-duration-predictor, nccer-sso, visual-eyes, shipyard) lead.
- [x] At least one detail page exists (all 6 do — case-study MDX bodies from #7).
- [x] External / repo / paper / video links use `target="_blank" rel="noreferrer"`.
- [x] Sitemap includes `/work` and `/work/<slug>` for every project.
- [ ] Visual QA on Vercel preview deploy once CI publishes it.

Acceptance from #9:
- [x] Index renders all projects from #7.
- [x] At least one project has a detail page (all 6 do).
- [x] Links work.
- [x] No raw image assets shipped — projects are text-first per `docs/design.md`; image optimization (`next/image`) isn't exercised yet but the route is ready for it when project frontmatter gains a `cover` field.