### PR TITLE
feat: project images on /work + VisualEyes link relabel

### DIFF
--- a/app/components/project-image.tsx
+++ b/app/components/project-image.tsx
@@ -1,0 +1,80 @@
+import Image from 'next/image';
+
+import type { Project } from '@/lib/work';
+
+type Props = {
+  project: Project;
+  /**
+   * `card` — index-card aspect, lazy-loaded, smaller sizes hint.
+   * `hero` — detail-page hero, eager-loaded with priority for LCP.
+   */
+  variant: 'card' | 'hero';
+  className?: string;
+};
+
+const SIZES_BY_VARIANT: Record<Props['variant'], string> = {
+  card: '(min-width: 640px) 33vw, 100vw',
+  hero: '(min-width: 768px) 720px, 100vw',
+};
+
+/**
+ * Project visual — uses the frontmatter `image` when present, otherwise
+ * renders a monochrome initial-card fallback so projects without a
+ * screenshot still get a real visual element instead of a blank space.
+ *
+ * `lib/work.ts` strips the `image` field when the referenced file is
+ * missing from `public/`, so by the time we render here `project.image`
+ * means "asset exists" — no broken-img edge case to handle in JSX.
+ */
+export function ProjectImage({ project, variant, className }: Props) {
+  const { frontmatter, slug } = project;
+  const wrapperClass = [
+    'relative overflow-hidden rounded-lg border border-border bg-bg-elevated',
+    variant === 'hero' ? 'aspect-[16/9]' : 'aspect-[4/3]',
+    className ?? '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  if (frontmatter.image) {
+    return (
+      <div className={wrapperClass}>
+        <Image
+          src={frontmatter.image}
+          alt={frontmatter.imageAlt ?? `${frontmatter.title} — project preview`}
+          fill
+          sizes={SIZES_BY_VARIANT[variant]}
+          priority={variant === 'hero'}
+          className="object-cover"
+        />
+      </div>
+    );
+  }
+
+  const initial = frontmatter.title.trim().charAt(0).toUpperCase() || '·';
+  return (
+    <div
+      className={`${wrapperClass} bg-gradient-to-br from-bg-elevated via-bg to-bg-elevated`}
+      role="img"
+      aria-label={`${frontmatter.title} — placeholder`}
+      data-project-slug={slug}
+    >
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span
+          aria-hidden="true"
+          className="font-display text-7xl font-medium tracking-tight text-fg-muted/40 sm:text-8xl"
+        >
+          {initial}
+        </span>
+      </div>
+      <div className="absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 border-t border-border bg-bg/60 px-3 py-2 backdrop-blur-sm">
+        <span className="font-mono text-[10px] uppercase tracking-widest text-fg-muted">
+          {frontmatter.title}
+        </span>
+        <span className="font-mono text-[10px] uppercase tracking-widest text-fg-muted">
+          {frontmatter.year}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { ProjectImage } from '@/app/components/project-image';
 import { formatLinkLabel, getAllProjects, getProjectBySlug } from '@/lib/work';
 import { SITE_TITLE } from '@/lib/site';
 
@@ -119,6 +120,8 @@ export default async function ProjectPage({
           </p>
         ) : null}
       </header>
+
+      <ProjectImage project={project} variant="hero" className="mb-10 sm:mb-12" />
 
       <div className="prose-post space-y-6 text-base leading-relaxed text-fg sm:text-lg [&_a]:text-accent [&_a]:underline-offset-4 hover:[&_a]:underline">
         <MDXContent />

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { ProjectImage } from '@/app/components/project-image';
 import { formatLinkLabel, getAllProjects } from '@/lib/work';
 
 const WORK_DESCRIPTION =
@@ -71,7 +72,14 @@ export default async function WorkIndexPage() {
             return (
               <li key={slug} className="py-10 sm:py-12">
                 <article className="grid gap-6 sm:grid-cols-[1fr_2fr] sm:gap-10">
-                  <div className="space-y-2">
+                  <div className="space-y-4">
+                    <Link
+                      href={`/work/${slug}`}
+                      aria-label={`Open ${frontmatter.title}`}
+                      className="block transition-opacity hover:opacity-90"
+                    >
+                      <ProjectImage project={project} variant="card" />
+                    </Link>
                     <p className="font-mono text-xs uppercase tracking-widest text-fg-muted">
                       <span>{frontmatter.role}</span>
                       <span aria-hidden="true"> · </span>

--- a/content/work/cdot-duration-predictor.mdx
+++ b/content/work/cdot-duration-predictor.mdx
@@ -8,6 +8,8 @@ links:
   external: 'https://pmodev.codot.gov/contracttimes'
   paper: 'https://pooledfund.org/details/study/489'
 featured: true
+image: '/work/cdot-duration-predictor.png'
+imageAlt: 'CDOT Construction Duration Predictor — web app screenshot'
 ---
 
 Built an artificial neural network for the [Colorado Department of Transportation](https://www.codot.gov/) to predict construction duration for highway projects based on estimated material quantities and geographic attributes.

--- a/content/work/express-delphi.mdx
+++ b/content/work/express-delphi.mdx
@@ -9,6 +9,8 @@ links:
   github: 'https://github.com/mattsears18/express-delphi-meteor'
   video: 'https://www.youtube.com/watch?v=gEY-Hcdg7vc&t=851s'
 featured: false
+image: '/work/express-delphi.png'
+imageAlt: 'Express Delphi — Delphi Method web app screenshot'
 ---
 
 A web app for running [the Delphi Method](https://www.researchgate.net/publication/255488148_Qualitative_Research_Application_of_the_Delphi_Method_to_CEM_Research) — a structured group decision-making process — about 50× faster than the conventional paper-driven workflow.

--- a/content/work/lightwork.mdx
+++ b/content/work/lightwork.mdx
@@ -7,6 +7,8 @@ tech: ['Expo', 'React Native', 'Expo Router', 'Firebase', 'Firestore', 'Algolia'
 links:
   external: 'https://lightwork-gray.vercel.app'
 featured: true
+image: '/work/lightwork.png'
+imageAlt: 'Lightwork — volunteer task management app screenshot'
 ---
 
 [Lightwork](https://lightwork-gray.vercel.app) is a volunteer task management app for groups that organize collective work. Members join groups, post tasks that need volunteers, and sign up to help — with real-time updates powered by Firestore.

--- a/content/work/nccer-sso.mdx
+++ b/content/work/nccer-sso.mdx
@@ -7,6 +7,8 @@ tech: ['Node.js', 'OAuth 2.0', 'OpenID Connect', 'AWS']
 links:
   external: 'https://web.account.nccer.org'
 featured: true
+image: '/work/nccer-sso.png'
+imageAlt: 'NCCER Single Sign-On — login screen'
 ---
 
 When I joined [NCCER](https://www.nccer.org) in 2019, [Single Sign-On](https://web.account.nccer.org) was the single most-requested feature from customers.

--- a/content/work/shipyard.mdx
+++ b/content/work/shipyard.mdx
@@ -8,6 +8,8 @@ links:
   external: 'https://github.com/mattsears18/shipyard'
   github: 'https://github.com/mattsears18/shipyard'
 featured: true
+image: '/work/shipyard.png'
+imageAlt: 'Shipyard — Claude Code plugin terminal session'
 ---
 
 [Shipyard](https://github.com/mattsears18/shipyard) is an experimental [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin that runs an autonomous engineering loop. It finds work (deep audits across UX, performance, security, a11y, SEO, privacy, dev experience, tech debt, and more — each finding becomes a GitHub issue), refines raw user feedback into actionable tickets, and burns down the backlog with a rolling pool of parallel workers in isolated git worktrees.

--- a/content/work/visual-eyes.mdx
+++ b/content/work/visual-eyes.mdx
@@ -9,6 +9,8 @@ links:
   github: 'https://github.com/mattsears18/visual-eyes'
   paper: 'https://www.researchgate.net/publication/343178511_Advanced_Eye_Tracking_Analysis_for_Investigating_Construction_Craft_Professional_Interactions_with_2D_Drawings'
 featured: true
+image: '/work/visual-eyes.png'
+imageAlt: 'VisualEyes — eye-tracking analysis app screenshot'
 ---
 
 A web app for visualizing and analyzing eye-tracking data from the dominant commercial hardware vendors.

--- a/content/work/visual-eyes.mdx
+++ b/content/work/visual-eyes.mdx
@@ -5,7 +5,7 @@ year: '2018–2020'
 summary: 'Eye-tracking analysis app that became the foundation of my PhD dissertation and five published papers.'
 tech: ['React', 'Meteor', 'MongoDB', 'Vercel', 'Plotly', 'jStat']
 links:
-  external: 'https://www.youtube.com/watch?v=Ed6oByh5tJw'
+  youtube: 'https://www.youtube.com/watch?v=Ed6oByh5tJw'
   github: 'https://github.com/mattsears18/visual-eyes'
   paper: 'https://www.researchgate.net/publication/343178511_Advanced_Eye_Tracking_Analysis_for_Investigating_Construction_Craft_Professional_Interactions_with_2D_Drawings'
 featured: true

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -7,11 +7,18 @@ import matter from 'gray-matter';
  * Frontmatter shape for `content/work/*.mdx` projects.
  *
  * Required: title, role, year, summary, tech.
- * Optional: links (external/repo/paper/video — open set), featured (boolean).
+ * Optional: links (external/repo/paper/video — open set), featured (boolean),
+ * image + imageAlt (thumbnail / hero — see `image` rules below).
  *
  * `links` is intentionally a loose record so MDX authors can add new keys
  * (paper / video / case-study) without re-touching this type — the index +
  * detail pages render whatever keys are present using `formatLinkLabel`.
+ *
+ * `image` is a public-root path like `/work/lightwork.png`. If the file is
+ * missing from `public/`, `getAllProjects` strips the field at read time so
+ * the UI falls back to the generated initial-card instead of rendering a
+ * broken <Image>. This lets MDX authors set the convention path eagerly and
+ * drop in the real PNG later without a page-render regression.
  */
 export type ProjectLinks = Record<string, string>;
 
@@ -23,6 +30,8 @@ export type ProjectFrontmatter = {
   tech: string[];
   links?: ProjectLinks;
   featured?: boolean;
+  image?: string;
+  imageAlt?: string;
 };
 
 export type Project = {
@@ -32,6 +41,16 @@ export type Project = {
 };
 
 const WORK_DIR = path.join(process.cwd(), 'content', 'work');
+const PUBLIC_DIR = path.join(process.cwd(), 'public');
+
+async function fileExists(absPath: string): Promise<boolean> {
+  try {
+    await fs.access(absPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function readProjectFile(filename: string): Promise<Project | null> {
   if (!filename.endsWith('.mdx')) return null;
@@ -50,6 +69,17 @@ async function readProjectFile(filename: string): Promise<Project | null> {
     throw new Error(
       `Project ${slug} is missing required frontmatter (title, role, year, summary, tech[])`,
     );
+  }
+  if (frontmatter.image) {
+    // public-root paths only; strip the field if the asset isn't on disk so
+    // the UI renders the initial-card fallback instead of a broken <Image>.
+    const onDisk = frontmatter.image.startsWith('/')
+      ? path.join(PUBLIC_DIR, frontmatter.image)
+      : null;
+    if (!onDisk || !(await fileExists(onDisk))) {
+      delete frontmatter.image;
+      delete frontmatter.imageAlt;
+    }
   }
   return { slug, frontmatter, content };
 }

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -140,6 +140,7 @@ export function formatLinkLabel(key: string): string {
     github: 'GitHub',
     paper: 'Paper',
     video: 'Video',
+    youtube: 'YouTube',
     demo: 'Demo',
   };
   if (known[key]) return known[key];

--- a/public/work/README.md
+++ b/public/work/README.md
@@ -1,0 +1,26 @@
+# Project images
+
+Drop project screenshots into this directory using the slug from `content/work/<slug>.mdx`:
+
+```
+public/work/
+├── cdot-duration-predictor.png
+├── express-delphi.png
+├── lightwork.png
+├── nccer-sso.png
+├── shipyard.png
+└── visual-eyes.png
+```
+
+The path in each project's frontmatter (`image: /work/<slug>.png`) is already wired up. When the file lands in this directory, `lib/work.ts` picks it up and the index card + detail page hero render it instead of the fallback initial-card.
+
+## Recommended specs
+
+- **Format**: PNG or JPG (PNG for UI screenshots, JPG for photography). WebP also works.
+- **Aspect ratio**: ~16:9 for hero (detail page), ~4:3 for card thumbnails — the source can be either, the layout crops via `object-cover`. Wide is fine.
+- **Size**: at least 1200px wide so the detail-page hero stays sharp on 2×/3× displays. Next.js Image optimizes the served sizes automatically.
+- **File size**: keep under ~500 KB per image. Run through [Squoosh](https://squoosh.app) or `cwebp -q 80` before committing.
+
+## Fallback
+
+If a file is missing from this directory, `lib/work.ts` strips the `image` frontmatter field at read time and `<ProjectImage>` renders a monochrome initial-card placeholder. So adding/removing images is safe — no broken `<img>` tags, no build errors.


### PR DESCRIPTION
## Summary

- **Project images** — adds optional `image` + `imageAlt` frontmatter to each `content/work/*.mdx`. Index card thumbnails + detail-page heroes render via `next/image`; missing files fall back to a monochrome initial-card so projects without a screenshot still look intentional.
- **VisualEyes link relabel** — its external URL is actually a YouTube demo, not a live app. Renames the link key `external` → `youtube` and adds a `youtube` entry to `formatLinkLabel`'s known map so the row reads `YouTube · GitHub · Paper`.

`lib/work.ts` strips `image`/`imageAlt` at read time if the file isn't on disk, so dropping a PNG into `public/work/<slug>.png` later just works — no broken `<img>`, no rebuild ceremony.

## Test plan

- [x] `npm run build` — all 18 static pages prerender cleanly
- [x] `/work` renders 6 cards with initial-card fallbacks (no PNGs committed yet)
- [x] `/work/visualeyes` shows `YouTube · GitHub · Paper`, other detail pages unchanged
- [x] dev-server screenshot confirms `V` and `C` initial-cards render at expected aspect
- [ ] Drop real screenshots into `public/work/` and confirm they replace the fallback per-slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)