### PR TITLE
feat(blog): code blocks + prose styles

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -48,3 +48,94 @@
     @apply outline-none ring-2 ring-accent ring-offset-2 ring-offset-bg;
   }
 }
+
+@layer components {
+  /*
+   * Long-form prose styles for blog posts + work case studies. Applied to
+   * the wrapper div around `<MDXContent />` in both /blog/[slug] and
+   * /work/[slug]. Don't use the Tailwind typography plugin — keeps the
+   * stylesheet narrow and on-theme.
+   */
+  .prose-post {
+    @apply text-base leading-relaxed text-fg sm:text-lg;
+  }
+
+  .prose-post > * + * {
+    @apply mt-6;
+  }
+
+  .prose-post h2 {
+    @apply mt-12 font-display text-2xl font-medium tracking-tight text-fg sm:text-3xl;
+  }
+  .prose-post h3 {
+    @apply mt-10 font-display text-xl font-medium tracking-tight text-fg sm:text-2xl;
+  }
+  .prose-post h2 + p,
+  .prose-post h3 + p {
+    @apply mt-4;
+  }
+
+  .prose-post a {
+    @apply text-accent underline-offset-4;
+  }
+  .prose-post a:hover {
+    @apply underline;
+  }
+
+  .prose-post ul {
+    @apply ml-6 list-disc;
+  }
+  .prose-post ol {
+    @apply ml-6 list-decimal;
+  }
+  .prose-post li + li {
+    @apply mt-2;
+  }
+
+  .prose-post blockquote {
+    @apply border-l-2 border-accent pl-4 italic text-fg-muted;
+  }
+
+  .prose-post hr {
+    @apply my-10 border-border;
+  }
+
+  /*
+   * Inline code (single backticks). `:not(pre) > code` excludes block code
+   * spans inside the rehype-pretty-code <pre> so token styling there isn't
+   * clobbered.
+   */
+  .prose-post :not(pre) > code {
+    @apply rounded border border-border bg-bg-elevated px-1.5 py-0.5 font-mono text-[0.875em];
+  }
+
+  /*
+   * Code blocks (rehype-pretty-code output). The plugin emits
+   * `<figure data-rehype-pretty-code-figure><pre data-language="..."><code style="display:grid">`
+   * with shiki token spans carrying `--shiki-light` / `--shiki-dark` CSS
+   * variables. `keepBackground: false` in next.config.js means the <pre>
+   * doesn't get a theme background — we apply our own from the design tokens.
+   */
+  .prose-post figure[data-rehype-pretty-code-figure] {
+    @apply my-8;
+  }
+
+  .prose-post pre {
+    @apply overflow-x-auto rounded-lg border border-border bg-bg-elevated px-5 py-4 font-mono text-sm leading-relaxed;
+  }
+
+  .prose-post pre code {
+    @apply block;
+  }
+
+  .prose-post pre code [data-line] {
+    @apply block;
+  }
+
+  .prose-post pre code span {
+    color: var(--shiki-light);
+  }
+  .dark .prose-post pre code span {
+    color: var(--shiki-dark);
+  }
+}

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -123,7 +123,7 @@ export default async function ProjectPage({
 
       <ProjectImage project={project} variant="hero" className="mb-10 sm:mb-12" />
 
-      <div className="prose-post space-y-6 text-base leading-relaxed text-fg sm:text-lg [&_a]:text-accent [&_a]:underline-offset-4 hover:[&_a]:underline">
+      <div className="prose-post">
         <MDXContent />
       </div>
 


### PR DESCRIPTION
## Summary

Blog post code blocks were rendering as a wall of plain text with no container, padding, or visible syntax highlighting. Root cause: `.prose-post` was applied to the MDX body wrapper but had zero CSS attached anywhere.

## What changed

`app/globals.css` — defines `.prose-post` properly under `@layer components`:

- Paragraph spacing (`> * + *  →  mt-6`)
- Link styling (accent color, hover underline)
- List, heading, blockquote, hr styles
- **Inline code** (single backticks): rounded bg + border + mono font
- **Code blocks** (rehype-pretty-code output):
  - `figure` margin
  - `<pre>` rounded container, border, `bg-bg-elevated`, horizontal overflow
  - `<code>` lines stack as blocks
  - Shiki token spans wired to the dark-mode switch via the `--shiki-light` / `--shiki-dark` CSS vars the plugin emits (since `next.config.js` has `keepBackground: false`, the `<pre>` background comes from our design tokens, not the Shiki theme)

`app/work/[slug]/page.tsx` — strips the now-redundant `space-y-6`, `text-base`, `leading-relaxed`, `text-fg`, `sm:text-lg`, and `[&_a]:text-accent...` utilities from the MDX wrapper. `.prose-post` covers all of that centrally now.

## Test plan

- [x] `npm run build` — clean
- [x] Localhost screenshot of `/blog/hello-from-the-new-site` — code blocks render with container + syntax colors, paragraphs have proper spacing, links are accent-colored, inline `git push` has its own subtle background
- [ ] Spot-check `/work/<slug>` detail pages still look right (spacing + link styles via `.prose-post` instead of the stripped utilities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)