### PR TITLE
chore(rss): replace generic feed description

### DIFF
--- a/app/rss.xml/route.ts
+++ b/app/rss.xml/route.ts
@@ -4,7 +4,7 @@ import { getAllPosts } from '@/lib/posts';
 
 const SITE_URL = 'https://mattsears18.com';
 const SITE_TITLE = 'Matt Sears';
-const SITE_DESCRIPTION = 'Notes from a senior software engineer.';
+const SITE_DESCRIPTION = 'Building software, writing about it, occasionally arguing with it.';
 
 export const dynamic = 'force-static';
 


### PR DESCRIPTION
## Summary

- `SITE_DESCRIPTION` in `app/rss.xml/route.ts` was "Notes from a senior software engineer." — surfaced at the bottom of the main page via the RSS feed.
- Replaced with "Building software, writing about it, occasionally arguing with it." — points at subject + voice instead of leading with a title claim.

## Test plan
- [ ] `npm run build` — Next.js build still succeeds.
- [ ] Visit `/rss.xml` after deploy — confirm the `<description>` element in the channel reflects the new copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)