### PR TITLE
fix(security): add CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy headers

### DIFF
--- a/app/components/theme-script.tsx
+++ b/app/components/theme-script.tsx
@@ -34,7 +34,8 @@ const THEME_SCRIPT = `(function () {
   }
 })();`;
 
-export function ThemeScript() {
-  // eslint-disable-next-line react/no-danger -- payload is a hard-coded constant, see file header.
-  return <script dangerouslySetInnerHTML={{ __html: THEME_SCRIPT }} />;
+export function ThemeScript({ nonce }: { nonce?: string }) {
+  const innerHTML = { __html: THEME_SCRIPT };
+  // eslint-disable-next-line react/no-danger -- THEME_SCRIPT is a hard-coded constant, see file header.
+  return <script nonce={nonce} dangerouslySetInnerHTML={innerHTML} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono, Source_Serif_4 } from 'next/font/google';
 import { GeistSans } from 'geist/font/sans';
+import { headers } from 'next/headers';
 import { VercelToolbar } from '@vercel/toolbar/next';
 
 import './globals.css';
@@ -88,11 +89,16 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
   // Toolbar is gated on VERCEL_ENV: shows on preview + development, hidden on
   // production. Visitors never saw it anyway (auth-gated), but this kills the
   // overlay for signed-in team members on the production deploy too.
   const showVercelToolbar = process.env.VERCEL_ENV !== 'production';
+
+  // CSP nonce — see proxy.ts. Stamped onto the one inline <script> we
+  // emit (theme pre-paint); Next.js auto-stamps it onto its own framework
+  // scripts and the next/font-generated <style> blocks during SSR.
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
 
   return (
     <html
@@ -104,7 +110,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       suppressHydrationWarning
     >
       <head>
-        <ThemeScript />
+        <ThemeScript nonce={nonce} />
       </head>
       <body className="min-h-screen bg-bg text-fg">
         <SiteHeader />

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,26 @@ const rehypePrettyCodeOptions = {
   keepBackground: false,
 };
 
+/*
+ * Static defense-in-depth headers — see #38.
+ *
+ * The Content-Security-Policy header is NOT in this list: it carries a
+ * per-request nonce and is set by `proxy.ts` instead. The four headers
+ * below are static strings with no request-dependent data, so applying them
+ * here keeps them off the proxy hot path (and lets them apply to routes
+ * excluded from the proxy matcher — robots.txt, sitemap.xml, /_next/static,
+ * etc.).
+ */
+const securityHeaders = [
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
+  },
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
@@ -17,6 +37,14 @@ const nextConfig = {
   // under a home directory that has its own yarn.lock / package-lock.json).
   turbopack: {
     root: __dirname,
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/*
+ * Per-request CSP nonce — see #38.
+ *
+ * Next.js 16's App Router streams Server Components by emitting a stream of
+ * inline `<script>self.__next_f.push(...)</script>` tags whose contents vary
+ * per route, so a static hash-pinned CSP in `next.config.js` cannot allow
+ * them. The canonical fix from the Next.js docs is to set the CSP from a
+ * proxy with a per-request nonce and `'strict-dynamic'`; Next.js then
+ * auto-stamps that nonce onto every framework-emitted `<script>` and
+ * `<style>` during SSR, and `'strict-dynamic'` lets those allowlisted
+ * scripts load further chunks without listing them individually.
+ *
+ * Trade-off: the proxy forces dynamic rendering, so pages can't be served
+ * straight from the static prerender cache. For a low-traffic portfolio,
+ * the perf cost is negligible; the CDN still caches at the edge.
+ *
+ * The other four security headers (X-Frame-Options, X-Content-Type-Options,
+ * Referrer-Policy, Permissions-Policy) stay in `next.config.js` because they
+ * don't need per-request data and `headers()` there applies to every
+ * response — including the static asset paths excluded from this proxy's
+ * matcher.
+ *
+ * Vercel Toolbar (loaded only when VERCEL_ENV !== 'production' — see
+ * app/layout.tsx) pulls runtime assets from vercel.live and opens a
+ * websocket to *.pusher.com; allowlisted only on non-production deploys.
+ */
+export function proxy(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString('base64');
+  const isProduction = process.env.VERCEL_ENV === 'production';
+  const isDev = process.env.NODE_ENV === 'development';
+
+  const csp = [
+    `default-src 'self'`,
+    // 'strict-dynamic' propagates the nonce to scripts loaded by allowlisted
+    // ones, so we don't need to enumerate every chunk URL.
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ''}${isProduction ? '' : ' https://vercel.live'}`,
+    // Tailwind compiles to <style> blocks bound to the layout; Next.js
+    // auto-stamps the nonce onto those during SSR. Inline style attributes
+    // on per-element JSX (e.g. layout.tsx's `style={{ colorScheme }}`) are
+    // covered by 'unsafe-inline' in style-src-attr below.
+    `style-src 'self' 'nonce-${nonce}'${isProduction ? '' : ' https://vercel.live'}`,
+    // Per-element style="..." attributes used throughout the JSX. Browsers
+    // that don't support style-src-attr fall back to style-src, which
+    // does NOT include 'unsafe-inline' here — accept the modern-browser
+    // narrowing as a feature, not a bug.
+    `style-src-attr 'unsafe-inline'`,
+    `img-src 'self' data: blob:${isProduction ? '' : ' https://vercel.live https://vercel.com'}`,
+    `font-src 'self' data:${isProduction ? '' : ' https://vercel.live'}`,
+    `connect-src 'self'${isProduction ? '' : ' https://vercel.live wss://ws-us3.pusher.com https://sockjs-us3.pusher.com'}`,
+    `frame-src 'self'${isProduction ? '' : ' https://vercel.live'}`,
+    `frame-ancestors 'none'`,
+    `base-uri 'self'`,
+    `form-action 'self'`,
+    `object-src 'none'`,
+    `upgrade-insecure-requests`,
+  ].join('; ');
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-nonce', nonce);
+  requestHeaders.set('Content-Security-Policy', csp);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  response.headers.set('Content-Security-Policy', csp);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Run on every request path EXCEPT:
+     *   - /_next/static/* and /_next/image/*  (static chunks + image opt;
+     *     they don't render HTML and don't need a CSP)
+     *   - /favicon.ico, /robots.txt, /sitemap.xml, /rss.xml (no scripts)
+     *   - asset extensions served straight from /public
+     *
+     * Same exclusion list Next.js suggests in their CSP guide. The
+     * route handler files (robots.ts, sitemap.ts, rss.xml/) generate
+     * non-HTML responses where the CSP header has no security benefit;
+     * skipping them keeps the proxy off the hot path for crawler
+     * traffic and feed readers.
+     */
+    {
+      source:
+        '/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml|rss.xml|.*\\.(?:png|jpg|jpeg|gif|svg|webp|ico|woff|woff2|ttf|otf|map)$).*)',
+    },
+  ],
+};


### PR DESCRIPTION
Closes #38

## Summary

The five HTTP defense-in-depth headers were entirely missing from production responses (only HSTS was set). This PR adds them in two layers:

- **`next.config.js#headers()`** emits the four static headers (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()`) on every route, including non-HTML routes (`/robots.txt`, `/sitemap.xml`, `/rss.xml`, `/_next/static/*`).
- **`proxy.ts`** (new) emits a per-request CSP with a fresh base64 nonce. Uses `'strict-dynamic'` so the nonce-allowlisted scripts can transitively load chunks without enumerating them. Next.js auto-stamps the nonce onto its own framework `<script>`/`<style>` tags during SSR; the only repo-owned inline script (`ThemeScript`, the no-flash theme pre-paint) now receives the nonce via `app/layout.tsx` reading `x-nonce` from `next/headers` and passing it down.

## Design notes — why nonce instead of hash

The issue's suggested fix was a static hash-based CSP in `next.config.js`. I verified that doesn't work for Next.js 16's App Router: the streaming RSC payload emits a stream of inline `<script>self.__next_f.push(...)</script>` tags whose contents vary per route, so they can't all be hashed at build time. Per the [Next.js CSP docs](https://nextjs.org/docs/app/guides/content-security-policy), the canonical fix is a proxy (formerly middleware) with per-request nonces + `'strict-dynamic'`.

Trade-off: `proxy.ts` forces dynamic rendering on every HTML route (routes shifted from `○ Static` to `ƒ Dynamic` in the build output). For a low-traffic portfolio site the perf cost is negligible — Vercel still caches at the edge. Non-HTML routes (`robots.txt`, `sitemap.xml`, `rss.xml`, all `*.png`/`*.woff` etc.) are excluded from the proxy matcher and continue to be statically prerendered.

Vercel Toolbar (loaded only when `VERCEL_ENV !== 'production'`) pulls runtime assets from `vercel.live` and opens a websocket to `*.pusher.com`. Those origins are allowlisted in the CSP **only on non-production deploys**, keeping the production policy strict.

## CI note

This repo does not yet have a CI workflow (tracked separately by #49), so this PR will not have automated checks. The fix was verified locally with `next build` + `next start` and a Chrome DevTools console-message sweep across `/`, `/blog`, `/work`, `/blog/hello-from-the-new-site`, `/work/shipyard` — zero CSP violations, theme toggle round-trips correctly through `localStorage`.

## Test plan

- [ ] After merge + Vercel deploy, `curl -sI https://mattsears18.com/` returns `content-security-policy`, `x-frame-options`, `x-content-type-options`, `referrer-policy`, `permissions-policy`
- [ ] `curl -sI https://mattsears18.com/blog` and `/work` return the same set
- [ ] Page loads in the browser with no CSP violations in the console (theme pre-paint script runs, framework scripts hydrate, fonts load)
- [ ] [securityheaders.com](https://securityheaders.com/?q=mattsears18.com) grade jumps from F to A (or A+ if HSTS preload is set)
- [ ] Theme toggle still flips dark/light and persists across reloads