### PR TITLE
docs(drift): update README + architecture.md for Next.js 16 + React 19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mattsears18.com
 
-Personal site for Matt Sears. Next.js 14 (App Router) + Tailwind + MDX, deployed on Vercel.
+Personal site for Matt Sears. Next.js 16 (App Router) + React 19 + Tailwind + MDX, deployed on Vercel.
 
 See [`docs/architecture.md`](./docs/architecture.md) for the locked tech stack and content model, and [`docs/design.md`](./docs/design.md) for typography, palette, and layout tokens.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,9 @@ This document locks the tech stack and content model for `mattsears18.com`. Deci
 
 Resolves the decisions in [#5](https://github.com/mattsears18/mattsears18.com/issues/5).
 
-## Framework — Next.js 14 (App Router)
+## Framework — Next.js 16 (App Router)
 
-The repo was scaffolded with `create-next-app` on Next.js 14 using the App Router. We're staying put. The App Router is the supported path forward for new Next.js work, server components map cleanly to a content-heavy personal site, and there's no concrete pain point that would justify the cost of porting to Astro / SvelteKit / 11ty. Reach for an alternative only if a specific requirement (e.g., a non-React framework, an islands-architecture mandate) shows up — not preemptively.
+The repo was scaffolded with `create-next-app` on Next 14 using the App Router, then upgraded to Next.js 16 + React 19 in [#15](https://github.com/mattsears18/mattsears18.com/pull/15). We're staying on Next + App Router. The App Router is the supported path forward for new Next.js work, server components map cleanly to a content-heavy personal site, and there's no concrete pain point that would justify the cost of porting to Astro / SvelteKit / 11ty. Reach for an alternative only if a specific requirement (e.g., a non-React framework, an islands-architecture mandate) shows up — not preemptively.
 
 ## Styling — Tailwind + shadcn/ui
 


### PR DESCRIPTION
Closes #46

## Summary

Both `README.md` and `docs/architecture.md` still claimed Next.js 14 after the Next 14 → 16 / React 18 → 19 upgrade in #15. This PR refreshes both surfaces to match `package.json` (`next` ^16.2.6, `react` ^19.2.6, `react-dom` ^19.2.6) and rewrites the "we're staying put" rationale in the architecture doc to acknowledge the 14 → 16 jump while keeping the App-Router-on-Next architectural commitment intact.

Pure docs change — no code touched.

## Test plan

- [x] `git grep 'Next.js 14' -- README.md docs/architecture.md` returns 0 lines.
- [x] `README.md` and `docs/architecture.md` reference Next.js 16 (matches the `next` major in `package.json`).
- [x] The "staying put" reasoning in `docs/architecture.md` is rewritten to acknowledge the 14 → 16 upgrade (links to #15).