### PR TITLE
chore(dx): add CI workflow — lint, type-check, build on PR + push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        # `next lint` was removed in Next.js 16 and the current `lint` script
+        # fails until it's swapped for a direct ESLint invocation. Tracked in
+        # https://github.com/mattsears18/mattsears18.com/issues/80 — remove
+        # continue-on-error once #80 lands.
+        run: npm run lint --if-present
+        continue-on-error: true
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Closes #49
Closes #37

## Summary

Adds `.github/workflows/ci.yml` so every PR and every push to `main` runs `npm ci`, lint, `tsc --noEmit`, and `next build` under Node 20. Resolves the `audit:dx` finding that the repo had no CI signal.

- Triggers: `pull_request` to `main` + `push` to `main`.
- Single `ubuntu-latest` job; Node 20 (no `engines` field in `package.json`, no `.nvmrc` yet).
- Steps: `actions/checkout@v4`, `actions/setup-node@v4` with `cache: npm`, `npm ci`, `npm run lint --if-present` (gated — see below), `npx tsc --noEmit`, `npm run build`.

Pre-flight verification on current `main`:

| Step | Status |
|---|---|
| `npm ci` | passes |
| `npm run lint` | **fails** — `next lint` was removed in Next.js 16; the current `lint` script invokes it and Next interprets `lint` as a directory path |
| `npx tsc --noEmit` | passes |
| `npm run build` | passes |

To avoid shipping a workflow that's red on day one, the lint step is gated with `continue-on-error: true` and references the follow-up issue #80. Once #80 lands (`lint` script swapped for a direct `eslint` invocation), the `continue-on-error` flag can be removed in that PR.

Per dispatch directive, this PR does **not** add a required-check branch protection rule (separate one-time admin task) and does **not** enable Vercel deployment gating — the workflow runs purely as a CI signal.

#37 is closed as a duplicate of #49.

## Test plan

- [ ] CI workflow runs on this PR (it should — the workflow file landing on the branch triggers `pull_request: main` immediately).
- [ ] `Install dependencies`, `Type check`, `Build` steps pass green.
- [ ] `Lint` step fails (red) but does not fail the overall job because `continue-on-error: true` is set.
- [ ] After merge, the workflow runs once more on the `push: main` event.