### PR TITLE
feat(seo): add apple-touch-icon — branded 180×180 monogram via next/og

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,49 @@
+import { ImageResponse } from 'next/og';
+
+/*
+ * Apple touch icon (180×180). Renders at build time via `next/og`
+ * ImageResponse — no static PNG asset committed to the repo. Next.js's
+ * `apple-icon` file convention auto-injects the corresponding
+ * `<link rel="apple-touch-icon" sizes="180x180" type="image/png" ...>`
+ * tag into every route's <head> (see app-icons docs).
+ *
+ * Design follows the same language as `app/opengraph-image.tsx`:
+ * near-black background, sans monogram, orange accent period. iOS
+ * rounds the corners automatically on home-screen — no need to mask
+ * here. 180×180 is Apple's current default; the smaller 152/167
+ * variants are auto-derived by Safari from the 180 source.
+ */
+export const size = { width: 180, height: 180 };
+export const contentType = 'image/png';
+
+export default async function AppleIcon() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#0a0a0a',
+        color: '#fafaf9',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          fontSize: 96,
+          fontWeight: 600,
+          letterSpacing: '-0.04em',
+          lineHeight: 1,
+        }}
+      >
+        MS
+        <span style={{ color: '#f97316' }}>.</span>
+      </div>
+    </div>,
+    size,
+  );
+}


### PR DESCRIPTION
Closes #61

## Summary

- Adds `app/apple-icon.tsx` using Next.js's [apple-icon file convention](https://nextjs.org/docs/app/api-reference/file-conventions/metadata/app-icons), which auto-injects `<link rel="apple-touch-icon" sizes="180x180" type="image/png">` into every route's `<head>`.
- Renders dynamically at build time via `next/og`'s `ImageResponse` — same pattern already in use for `app/opengraph-image.tsx` and `app/twitter-image.tsx`, so no binary PNG is committed to the repo.
- Design follows the OG image and site hero: near-black (`#0a0a0a`) background, bold sans `MS` monogram in `#fafaf9`, orange accent period (`#f97316`). iOS rounds the corners automatically on home-screen install — no manual masking needed.

## Test plan

Verified locally against `next build && next start`:

- [x] `<link rel="apple-touch-icon" sizes="180x180" type="image/png" href="/apple-icon?...">` is present in the rendered `<head>` on `/`, `/blog`, and `/work` (root layout means every route inherits it).
- [x] `GET /apple-icon` returns `HTTP 200` with `content-type: image/png`.
- [x] The PNG payload is `180 x 180, 8-bit/color RGBA, non-interlaced` (verified via `file`).
- [x] `npx eslint app/apple-icon.tsx` passes.
- [x] `npx prettier --check app/apple-icon.tsx` passes.