### PR TITLE
feat(seo): add Person, WebSite, and BreadcrumbList JSON-LD schemas (#58)

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { JsonLd } from '@/app/components/json-ld';
+import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatPostDate, getAllPosts, getPostBySlug } from '@/lib/posts';
 import { SITE_TITLE } from '@/lib/site';
 
@@ -48,6 +50,13 @@ export default async function PostPage({ params }: { params: Promise<Params> }) 
 
   return (
     <article className="mx-auto max-w-reading py-12 sm:py-16">
+      <JsonLd
+        schema={breadcrumbListSchema([
+          { name: 'Home', path: '/' },
+          { name: 'Blog', path: '/blog' },
+          { name: post.frontmatter.title, path: `/blog/${slug}` },
+        ])}
+      />
       <nav className="mb-10">
         <Link
           href="/blog"

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { JsonLd } from '@/app/components/json-ld';
+import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatPostDate, getAllPosts } from '@/lib/posts';
 
 const BLOG_DESCRIPTION =
@@ -28,6 +30,12 @@ export default async function BlogIndexPage() {
 
   return (
     <div className="mx-auto max-w-reading py-16 sm:py-20">
+      <JsonLd
+        schema={breadcrumbListSchema([
+          { name: 'Home', path: '/' },
+          { name: 'Blog', path: '/blog' },
+        ])}
+      />
       <header className="mb-12 sm:mb-16">
         <p className="mb-4 font-mono text-xs uppercase tracking-widest text-fg-muted">Writing</p>
         <h1 className="font-display text-4xl font-medium tracking-tight text-fg sm:text-5xl">

--- a/app/components/json-ld.tsx
+++ b/app/components/json-ld.tsx
@@ -1,0 +1,57 @@
+import { headers } from 'next/headers';
+
+/**
+ * Render a `<script type="application/ld+json">` tag with the per-request
+ * CSP nonce stamped on — required by the strict-dynamic CSP set in
+ * `proxy.ts`. Without the nonce, browsers reject the inline script and
+ * search engines never see the structured data.
+ *
+ * SAFETY: The script payload is built from schema objects authored in
+ * `lib/json-ld.ts` (Person, WebSite, BreadcrumbList) — every string value
+ * is a hard-coded constant or a value derived from controlled sources
+ * (post frontmatter, project frontmatter, route slugs from
+ * generateStaticParams). No request-derived data, no fetched JSON, no
+ * user-submitted input ever enters the payload. The use of
+ * `dangerouslySetInnerHTML` is therefore safe by construction; an
+ * attacker would need write access to the schema generators or the MDX
+ * frontmatter to influence it, both of which are repo-controlled.
+ *
+ * Defense in depth: `JSON.stringify` escapes JSON-syntactic characters,
+ * and we additionally replace `<` with `<` so any future schema value
+ * containing a `</script>` substring cannot terminate the script tag
+ * early. JSON parsers treat the escape identically; HTML parsers never
+ * see the bare `<`. Same pattern used by Next.js's own framework-emitted
+ * inline scripts and by the existing `ThemeScript` component
+ * (`app/components/theme-script.tsx`). A DOMPurify-style HTML sanitizer
+ * is the wrong tool here — the payload is JSON, not HTML, and HTML
+ * sanitization would corrupt valid schema content.
+ *
+ * Accepts a single schema object OR an array — passing an array emits one
+ * `<script>` per schema, which is the recommended pattern (some validators
+ * fail on a top-level array of schemas in a single script tag).
+ */
+type SchemaObject = Record<string, unknown>;
+
+export async function JsonLd({ schema }: { schema: SchemaObject | SchemaObject[] }) {
+  const nonce = (await headers()).get('x-nonce') ?? undefined;
+  const schemas = Array.isArray(schema) ? schema : [schema];
+
+  return (
+    <>
+      {schemas.map((s, i) => {
+        const json = JSON.stringify(s).replace(/</g, '\\u003c');
+        // `react/no-danger` is not enabled by `eslint-config-next/core-web-vitals`,
+        // so no per-line disable is needed. The safety reasoning for using
+        // `dangerouslySetInnerHTML` here is documented in the file header.
+        return (
+          <script
+            key={i}
+            type="application/ld+json"
+            nonce={nonce}
+            dangerouslySetInnerHTML={{ __html: json }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,11 @@ import { headers } from 'next/headers';
 import { VercelToolbar } from '@vercel/toolbar/next';
 
 import './globals.css';
+import { JsonLd } from './components/json-ld';
 import { ThemeScript } from './components/theme-script';
 import { SiteHeader } from './components/site-header';
 import { SiteFooter } from './components/site-footer';
+import { personSchema, websiteSchema } from '@/lib/json-ld';
 import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '@/lib/site';
 
 /*
@@ -111,6 +113,13 @@ export default async function RootLayout({ children }: { children: React.ReactNo
     >
       <head>
         <ThemeScript nonce={nonce} />
+        {/*
+         * Site-wide Person + WebSite JSON-LD — see #58. The schemas describe
+         * the site owner (Person → Knowledge Panel) and the site itself
+         * (WebSite). BreadcrumbList is per-route, rendered by individual page
+         * components against their depth in the URL hierarchy.
+         */}
+        <JsonLd schema={[personSchema(), websiteSchema()]} />
       </head>
       <body className="min-h-screen bg-bg text-fg">
         <SiteHeader />

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
+import { JsonLd } from '@/app/components/json-ld';
 import { ProjectImage } from '@/app/components/project-image';
+import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatLinkLabel, getAllProjects, getProjectBySlug } from '@/lib/work';
 import { SITE_TITLE } from '@/lib/site';
 
@@ -60,6 +62,13 @@ export default async function ProjectPage({ params }: { params: Promise<Params> 
 
   return (
     <article className="mx-auto max-w-reading py-12 sm:py-16">
+      <JsonLd
+        schema={breadcrumbListSchema([
+          { name: 'Home', path: '/' },
+          { name: 'Work', path: '/work' },
+          { name: project.frontmatter.title, path: `/work/${slug}` },
+        ])}
+      />
       <nav className="mb-10">
         <Link
           href="/work"

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { JsonLd } from '@/app/components/json-ld';
 import { ProjectImage } from '@/app/components/project-image';
+import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatLinkLabel, getAllProjects } from '@/lib/work';
 
 const WORK_DESCRIPTION =
@@ -43,6 +45,12 @@ export default async function WorkIndexPage() {
 
   return (
     <div className="py-16 sm:py-20">
+      <JsonLd
+        schema={breadcrumbListSchema([
+          { name: 'Home', path: '/' },
+          { name: 'Work', path: '/work' },
+        ])}
+      />
       <header className="mb-12 max-w-reading sm:mb-16">
         <p className="mb-4 font-mono text-xs uppercase tracking-widest text-fg-muted">
           Selected work

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,0 +1,77 @@
+/**
+ * Schema.org JSON-LD generators — Person, WebSite, BreadcrumbList.
+ *
+ * These functions return plain JS objects that the `<JsonLd>` component
+ * (`app/components/json-ld.tsx`) serializes into a `<script type="application/ld+json">`
+ * tag. Keeping the shapes here (instead of inlining in pages) makes the
+ * schema.org compliance reviewable in one place and lets pages compose
+ * BreadcrumbList items without re-deriving the URL conventions.
+ *
+ * Conformance reference: https://schema.org/Person, /WebSite, /BreadcrumbList
+ * Validation: paste the rendered JSON into Google's Rich Results Test
+ * (https://search.google.com/test/rich-results) before declaring victory.
+ */
+import { SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/**
+ * The canonical Person schema for Matt — used in the site-wide root layout.
+ *
+ * `jobTitle` mirrors how he describes himself across the site (lead engineer,
+ * not generic "Software Engineer"). `sameAs` lists the public profile URLs
+ * Google uses to disambiguate the Knowledge Panel entity; keep it tight
+ * (GitHub + LinkedIn) — adding throwaway profiles dilutes the signal.
+ */
+export function personSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: SITE_TITLE,
+    url: SITE_URL,
+    jobTitle: 'Lead Software Engineer',
+    sameAs: ['https://github.com/mattsears18', 'https://www.linkedin.com/in/mattsears18/'],
+  } as const;
+}
+
+/**
+ * WebSite schema — used in the site-wide root layout.
+ *
+ * No `potentialAction` (sitelinks search) because the site has no on-site
+ * search endpoint to wire to. Adding a fake one would mislead Google's
+ * sitelinks-search-box rendering and produce a broken result.
+ */
+export function websiteSchema() {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: SITE_TITLE,
+    url: SITE_URL,
+    inLanguage: 'en-US',
+  } as const;
+}
+
+/**
+ * BreadcrumbList schema — one per page, reflecting the page's depth.
+ *
+ * `items` is an ordered array of `{ name, url }` pairs from the root crumb
+ * (Home) down to the current page. The current page itself IS included as
+ * the final item — Google's docs require the full chain to land the
+ * breadcrumb rich result.
+ *
+ * URLs are absolutized against `SITE_URL` because schema.org's BreadcrumbList
+ * requires absolute IRIs (relative URLs validate but don't render in Rich
+ * Results in practice).
+ */
+export type BreadcrumbItem = { name: string; path: string };
+
+export function breadcrumbListSchema(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: `${SITE_URL}${item.path}`,
+    })),
+  } as const;
+}


### PR DESCRIPTION
Closes #58

## Summary

Adds site-wide structured data so SERP crawlers can render rich results (Knowledge Panel for the Person entity, sitelinks for the WebSite, breadcrumb chips on deep pages).

- `Person` + `WebSite` render in the root layout (`app/layout.tsx`) — every route inherits both.
- `BreadcrumbList` renders per route in each depth-≥2 page component, against the route's hierarchy:
  - `/blog` → Home → Blog
  - `/blog/[slug]` → Home → Blog → \<post title>
  - `/work` → Home → Work
  - `/work/[slug]` → Home → Work → \<project title>
- A small `<JsonLd>` server component (`app/components/json-ld.tsx`) reads the per-request CSP nonce from `headers()` and stamps it onto each `<script type="application/ld+json">`. Without this, the strict-dynamic CSP in `proxy.ts` would block the inline scripts and search engines would never see the structured data.
- Schema generators live in `lib/json-ld.ts` so the schema.org compliance is reviewable in one place and pages don't re-derive URL conventions for breadcrumbs.

## Implementation notes

- Out of scope per dispatch prompt: `BlogPosting` / `Article` / `CreativeWork` schemas on detail pages. The issue body listed these as additional acceptance criteria, but the dispatch narrowed scope to Person + WebSite + BreadcrumbList. Filing as follow-up.
- `/` does not render a BreadcrumbList — a 1-item breadcrumb at depth 0 is non-conformant per Google's structured-data docs (breadcrumbs reflect a page's *position*, which the root has none of). Acceptance criteria say "BreadcrumbList appropriate to their depth" — at depth 0, the appropriate breadcrumb is none.
- `Person.jobTitle` is "Lead Software Engineer" (matches the bio across the site — lead engineer at SalesRiver — rather than the issue body's suggested generic "Software Engineer").
- `WebSite.potentialAction` (sitelinks search) is intentionally omitted — the site has no on-site search endpoint, and pointing at a fake one would produce a broken Rich Result.
- Defense in depth in `<JsonLd>`: `JSON.stringify` plus `<` → `<` substitution prevents any future `</script>` substring inside a schema value from terminating the script tag.

## Test plan

- [x] `npm run build` — clean, no TS errors, all 19 static pages generate
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Curl every route + grep for `application/ld+json` — Person + WebSite render site-wide with nonces; BreadcrumbList renders with correct depth on `/blog`, `/blog/[slug]`, `/work`, `/work/[slug]`
- [ ] Paste rendered JSON into [Google Rich Results Test](https://search.google.com/test/rich-results) after deploy to confirm no validator errors