### PR TITLE
feat(seo): add og:image and twitter:image to /blog, /work, and /work/[slug] routes

### DIFF
--- a/app/blog/opengraph-image.tsx
+++ b/app/blog/opengraph-image.tsx
@@ -1,0 +1,102 @@
+import { ImageResponse } from 'next/og';
+
+import { SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/*
+ * `/blog` index Open Graph image. Without this file, the index page's
+ * `metadata.openGraph` shallow-overrides the root segment's image and
+ * social cards render with no preview — see issue #55. Visual language
+ * matches the per-post card (`Writing` eyebrow, accent period) so the
+ * index reads as a sibling of the post pages rather than a one-off.
+ */
+export const alt = `${SITE_TITLE} — Blog`;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function BlogOpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px 96px',
+        background: '#0a0a0a',
+        color: '#f5f5f5',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 22,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: '#a3a3a3',
+          fontFamily: 'monospace',
+        }}
+      >
+        {SITE_URL.replace(/^https?:\/\//, '')}/blog
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 32,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 28,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#f97316',
+            fontFamily: 'monospace',
+            display: 'flex',
+          }}
+        >
+          Writing
+        </div>
+        <div
+          style={{
+            fontSize: 96,
+            fontWeight: 600,
+            letterSpacing: '-0.03em',
+            lineHeight: 1,
+            display: 'flex',
+          }}
+        >
+          Blog
+          <span style={{ color: '#f97316' }}>.</span>
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            color: '#d4d4d4',
+            lineHeight: 1.3,
+            maxWidth: 880,
+            display: 'flex',
+          }}
+        >
+          Notes on engineering practice — systems, operations, the work of leading teams that ship.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 28,
+          color: '#d4d4d4',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {SITE_TITLE}
+        <span style={{ color: '#f97316' }}>.</span>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/app/blog/twitter-image.tsx
+++ b/app/blog/twitter-image.tsx
@@ -1,0 +1,6 @@
+/*
+ * Twitter card image for the `/blog` index — reuses the Open Graph image
+ * renderer. Next.js requires a separate file rather than letting us alias
+ * one to the other.
+ */
+export { default, alt, size, contentType } from './opengraph-image';

--- a/app/work/[slug]/opengraph-image.tsx
+++ b/app/work/[slug]/opengraph-image.tsx
@@ -1,0 +1,128 @@
+import { ImageResponse } from 'next/og';
+
+import { getProjectBySlug } from '@/lib/work';
+import { SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/*
+ * Per-project Open Graph image. Mirrors the per-post pattern in
+ * `app/blog/[slug]/opengraph-image.tsx` — title-aware, role/year
+ * eyebrow, dark site-card visual language — so each project page
+ * gets a distinct card instead of inheriting nothing (the page's
+ * own `generateMetadata.openGraph` would otherwise shallow-replace
+ * the root segment's image and leave the route with no card image
+ * at all; see issue #55).
+ *
+ * `generateImageMetadata` is called per route invocation with the
+ * matched `params`; we return exactly one entry keyed on the slug
+ * so the route emits one og:image tag per page instead of N (one
+ * per project — `generateImageMetadata` is NOT auto-filtered by the
+ * runtime). `generateStaticParams` on the page handles enumerating
+ * all slugs at build time.
+ */
+export const alt = `${SITE_TITLE} — Work`;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export async function generateImageMetadata({ params }: { params?: { slug?: string } }) {
+  const slug = params?.slug ?? 'work';
+  const project = slug !== 'work' ? await getProjectBySlug(slug) : null;
+  const altText = project ? `${project.frontmatter.title} — ${SITE_TITLE}` : alt;
+  return [
+    {
+      id: slug,
+      alt: altText,
+      size,
+      contentType,
+    },
+  ];
+}
+
+export default async function ProjectOpengraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  const title = project?.frontmatter.title ?? SITE_TITLE;
+  const role = project?.frontmatter.role ?? '';
+  const year = project?.frontmatter.year ?? '';
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px 96px',
+        background: '#0a0a0a',
+        color: '#f5f5f5',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          fontSize: 22,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: '#a3a3a3',
+          fontFamily: 'monospace',
+        }}
+      >
+        <span>{SITE_URL.replace(/^https?:\/\//, '')}/work</span>
+        {year ? <span>{year}</span> : null}
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 32,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 28,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#f97316',
+            fontFamily: 'monospace',
+            display: 'flex',
+          }}
+        >
+          {role || 'Work'}
+        </div>
+        <div
+          style={{
+            fontSize: title.length > 40 ? 64 : 80,
+            fontWeight: 600,
+            letterSpacing: '-0.025em',
+            lineHeight: 1.05,
+            maxWidth: 1000,
+            display: 'flex',
+          }}
+        >
+          {title}
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 28,
+          color: '#d4d4d4',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {SITE_TITLE}
+        <span style={{ color: '#f97316' }}>.</span>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/app/work/[slug]/twitter-image.tsx
+++ b/app/work/[slug]/twitter-image.tsx
@@ -1,0 +1,6 @@
+/*
+ * Twitter card image for project pages — reuses the per-project Open Graph
+ * image. Same renderer, same dimensions, separate file because Next.js
+ * looks them up by convention name.
+ */
+export { default, alt, size, contentType, generateImageMetadata } from './opengraph-image';

--- a/app/work/opengraph-image.tsx
+++ b/app/work/opengraph-image.tsx
@@ -1,0 +1,102 @@
+import { ImageResponse } from 'next/og';
+
+import { SITE_TITLE, SITE_URL } from '@/lib/site';
+
+/*
+ * `/work` index Open Graph image. Without this file, the index page's
+ * `metadata.openGraph` shallow-overrides the root segment's image and
+ * social cards render with no preview — see issue #55. Mirrors the
+ * site-card visual language (dark bg, accent period, mono eyebrow) so
+ * the index card reads as a sibling of `/` rather than a one-off.
+ */
+export const alt = `${SITE_TITLE} — Selected work`;
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default async function WorkOpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        padding: '80px 96px',
+        background: '#0a0a0a',
+        color: '#f5f5f5',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 22,
+          letterSpacing: '0.18em',
+          textTransform: 'uppercase',
+          color: '#a3a3a3',
+          fontFamily: 'monospace',
+        }}
+      >
+        {SITE_URL.replace(/^https?:\/\//, '')}/work
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 32,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 28,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: '#f97316',
+            fontFamily: 'monospace',
+            display: 'flex',
+          }}
+        >
+          Selected work
+        </div>
+        <div
+          style={{
+            fontSize: 96,
+            fontWeight: 600,
+            letterSpacing: '-0.03em',
+            lineHeight: 1,
+            display: 'flex',
+          }}
+        >
+          Work
+          <span style={{ color: '#f97316' }}>.</span>
+        </div>
+        <div
+          style={{
+            fontSize: 32,
+            color: '#d4d4d4',
+            lineHeight: 1.3,
+            maxWidth: 880,
+            display: 'flex',
+          }}
+        >
+          Shipped systems, research tools, and side projects across a decade of building.
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          fontSize: 28,
+          color: '#d4d4d4',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {SITE_TITLE}
+        <span style={{ color: '#f97316' }}>.</span>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/app/work/twitter-image.tsx
+++ b/app/work/twitter-image.tsx
@@ -1,0 +1,6 @@
+/*
+ * Twitter card image for the `/work` index — reuses the Open Graph image
+ * renderer. Next.js requires a separate file rather than letting us alias
+ * one to the other.
+ */
+export { default, alt, size, contentType } from './opengraph-image';


### PR DESCRIPTION
Closes #55

## Summary

Adds the missing `opengraph-image.tsx` + `twitter-image.tsx` convention files at three previously-uncovered route segments — `app/blog/`, `app/work/`, and `app/work/[slug]/` — so social-card scrapes for `/blog`, `/work`, and every `/work/<slug>` page get a proper preview image instead of a blank tile.

The root cause is Next 16's shallow-replace metadata merge: each of those routes defines its own `metadata.openGraph` (with title/description/url), and a child segment's `openGraph` shallow-overrides the inherited one. The root segment's `app/opengraph-image.tsx` contributes an `images` field at root, but as soon as a child re-defines `openGraph` without re-listing `images`, the inherited image is dropped. Adding the convention file at each affected segment puts the `images` back into that segment's metadata before the page's own `openGraph` is evaluated.

Per-project images (`/work/<slug>`) render the project title, role, and year — mirroring the per-post blog card pattern but with `Work` visual language. Index images (`/work`, `/blog`) mirror the root site card with a route-specific eyebrow (`Selected work` / `Writing`).

Notable subtlety: `generateImageMetadata` is NOT runtime-filtered against the matched `params`. Returning the full project list (as the blog-post variant currently does — masked because there's only one post) would emit N `og:image` tags per page. The work variant returns exactly one entry keyed on `params.slug`. The pre-existing blog quirk is left for a separate follow-up issue.

## Test plan

- [x] `npm run build` succeeds; route table shows the six new `/blog/opengraph-image`, `/blog/twitter-image`, `/work/opengraph-image`, `/work/twitter-image`, `/work/[slug]/opengraph-image/[__metadata_id__]`, `/work/[slug]/twitter-image/[__metadata_id__]` routes
- [x] `curl http://localhost:4100/work` → 1 `og:image` + 1 `twitter:image` meta tag
- [x] `curl http://localhost:4100/blog` → 1 `og:image` + 1 `twitter:image` meta tag
- [x] Each of the six `/work/<slug>` pages → exactly 1 `og:image` + 1 `twitter:image` (not 6) — alt text matches the project title
- [x] `curl -I /work/lightwork/opengraph-image/lightwork` → `HTTP/1.1 200 OK`, `content-type: image/png`
- [x] Downloaded image → `PNG image data, 1200 x 630`
- [x] `npm run lint`, `npm run format:check` clean