### PR TITLE
chore(dx): enable automated dependency updates via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      npm-major:
+        update-types:
+          - major
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+      actions-major:
+        update-types:
+          - major


### PR DESCRIPTION
Closes #53

## Summary

Adds `.github/dependabot.yml` to enable weekly Dependabot scans for both the npm root package and GitHub Actions. Minor and patch updates are grouped per ecosystem to keep PR noise low; major updates are grouped separately so they get individual review attention.

## Test plan

- [ ] `.github/dependabot.yml` is present and valid YAML.
- [ ] Configures both `npm` (root `/`) and `github-actions` ecosystems on a weekly cadence.
- [ ] Groups minor/patch updates per ecosystem; major updates land in a separate group.
- [ ] GitHub recognizes the config — Dependabot tab in the repo's Insights surfaces the schedule after merge.