### PR TITLE
fix(web): drop home hero eyebrow that restated the brand

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,8 +28,6 @@ export default function Home() {
         aria-labelledby="hero-heading"
         className="flex min-h-[70vh] flex-col justify-center py-16 sm:py-24 lg:min-h-[78vh]"
       >
-        <p className="mb-6 font-mono text-sm uppercase tracking-widest text-fg-muted">Matt Sears</p>
-
         <h1
           id="hero-heading"
           className="max-w-3xl font-display text-display-sm font-medium tracking-tight text-fg sm:text-display-md lg:text-display-lg"


### PR DESCRIPTION
Closes #76

## Summary
The home hero's eyebrow rendered `Matt Sears` — the same brand text already present in the header logo link, roughly 44px above. The repetition added no information and was inconsistent with how eyebrows are used elsewhere on the site (section labels like `About` / `Writing`, page-kind labels like `Selected Work`, role/date meta on detail pages).

Per the issue's option 2, drop the eyebrow entirely and let the H1 anchor the hero. This is the smallest fix that satisfies all four acceptance criteria.

## Test plan
- [ ] Visual check on `/` — header brand link is no longer immediately followed by a duplicate "MATT SEARS" eyebrow; H1 anchors the hero.
- [ ] H1 vertical position still feels intentional (the hero section retains `min-h-[70vh]` / `lg:min-h-[78vh]` with vertical centering, so the H1 stays comfortably below the header).
- [ ] No regression to other eyebrow surfaces — only `app/page.tsx`'s hero `<p>` is removed; `/blog` ("Writing"), `/work` ("Selected Work"), `/work/[slug]`, `/blog/[slug]`, and the home page's own "About" eyebrow are untouched.
- [ ] `npm run lint`, `npm run format:check`, `npm run build` all pass locally.