### PR TITLE
fix(seo,web): drop trailing slash from home sitemap entry (#70)

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -27,7 +27,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const staticRoutes: MetadataRoute.Sitemap = [
     {
-      url: `${SITE_URL}/`,
+      // No trailing slash — matches the canonical tag rendered by `app/page.tsx`
+      // (Next.js resolves `alternates.canonical: '/'` against `metadataBase` and
+      // drops the slash), the convention used by every other route on the site
+      // (`/blog`, `/work`, `/blog/:slug`, `/work/:slug`), and `SITE_URL` itself.
+      // See #70.
+      url: SITE_URL,
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 1.0,


### PR DESCRIPTION
Closes #70

## Summary

The home page canonical tag rendered `https://mattsears18.com` (Next.js drops the trailing slash when resolving `alternates.canonical: '/'` against `metadataBase`), but the sitemap's home entry rendered `https://mattsears18.com/`. Aligns the sitemap with the canonical tag — and with every other route on the site (`/blog`, `/work`, `/blog/:slug`, `/work/:slug`), `SITE_URL` itself, the `robots.txt` host, the RSS feed link, the OpenGraph URLs, and the JSON-LD schemas, all of which already use the no-trailing-slash form.

Picked "drop the slash from the sitemap" over "add the slash everywhere else" because (a) no-trailing-slash is the dominant convention across the entire codebase — the sitemap home entry was the only outlier — and (b) Next.js' default URL convention (`trailingSlash: false`, unset in `next.config.js`) renders the canonical tag without the slash, so adding slashes to canonicals would fight the framework.

## Test plan

- [x] `npm run build` succeeds
- [x] `npx eslint app/sitemap.ts` clean
- [x] `npx prettier --check app/sitemap.ts` passes
- [x] Built sitemap output (`.next/server/app/sitemap.xml.body`) verified — home entry now reads `<loc>https://mattsears18.com</loc>` (matching the canonical tag)
- [x] All other sitemap entries unchanged (no regression on `/blog`, `/work`, post / project slugs)