### PR TITLE
fix(a11y): add skip-to-main-content link in root layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -122,8 +122,25 @@ export default async function RootLayout({ children }: { children: React.ReactNo
         <JsonLd schema={[personSchema(), websiteSchema()]} />
       </head>
       <body className="min-h-screen bg-bg text-fg">
+        {/*
+         * Skip-to-main-content link — WCAG 2.1 AA 2.4.1 (Bypass Blocks).
+         * Must be the first focusable element in the document so the very
+         * first Tab keystroke surfaces it. Visually hidden with `sr-only`
+         * until focused, then promoted to a fixed pill in the top-left.
+         * Contrast on the focused state: `bg-bg` + `text-fg` is ~17:1 in
+         * both light and dark themes (well above AA's 4.5:1). The site's
+         * global `:focus-visible` rule layers an accent ring on top.
+         */}
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded focus:border focus:border-border focus:bg-bg focus:px-4 focus:py-2 focus:font-sans focus:text-sm focus:font-medium focus:text-fg"
+        >
+          Skip to main content
+        </a>
         <SiteHeader />
-        <main className="mx-auto max-w-container px-6 sm:px-12">{children}</main>
+        <main id="main" className="mx-auto max-w-container px-6 sm:px-12">
+          {children}
+        </main>
         <SiteFooter />
         {showVercelToolbar ? <VercelToolbar /> : null}
       </body>


### PR DESCRIPTION
Closes #71

## Summary

Adds a visually-hidden "Skip to main content" link as the first focusable element in the root layout (`app/layout.tsx`) and a matching `id="main"` on the layout's `<main>` wrapper. Satisfies WCAG 2.1 AA 2.4.1 (Bypass Blocks) — keyboard users no longer have to Tab through the header (logo, Work, Blog, theme toggle) on every route to reach page content.

The link uses Tailwind's built-in `sr-only` utility (hidden by default) plus `focus:not-sr-only` + fixed-positioning utilities (top-left pill when focused). The focused state uses `bg-bg` + `text-fg`, which is ~17:1 contrast in both light and dark themes — well above WCAG AA's 4.5:1 threshold. The site's existing `:focus-visible` rule layers an accent ring on top.

## Test plan

- [ ] On the home page, press Tab once — the first focused element is "Skip to main content", visible as a pill in the top-left.
- [ ] Press Enter — focus jumps to `<main id="main">` and the next Tab lands inside main content (skipping the header nav).
- [ ] On `/blog`, `/work`, and a case-study route (e.g. `/work/<slug>`), repeat — the link is present and works on every route.
- [ ] Mouse-only use: the link is not visible (verified via `sr-only`).
- [ ] Both light and dark themes: focused state has sufficient contrast (visible against the page background).