### PR TITLE
fix(a11y,web): collapse work-card duplicate links to a single stretched-link

### DIFF
--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -78,15 +78,23 @@ export default async function WorkIndexPage() {
             const links = frontmatter.links ?? {};
             return (
               <li key={slug} className="py-10 sm:py-12">
-                <article className="grid gap-6 sm:grid-cols-[1fr_2fr] sm:gap-10">
+                {/*
+                 * Single-link card pattern (a11y, issue #74): only the title
+                 * `<Link>` is in the accessibility tree / Tab order. It covers
+                 * the entire card via a `::before` overlay (`before:absolute
+                 * before:inset-0`), so sighted mouse users can still click the
+                 * image to navigate, but screen-reader and keyboard users get
+                 * exactly one stop per card. External links in the right
+                 * column carry `relative z-10` so they stay clickable above
+                 * the overlay.
+                 */}
+                <article className="group relative grid gap-6 sm:grid-cols-[1fr_2fr] sm:gap-10">
                   <div className="space-y-4">
-                    <Link
-                      href={`/work/${slug}`}
-                      aria-label={`Open ${frontmatter.title}`}
-                      className="block transition-opacity hover:opacity-90"
-                    >
-                      <ProjectImage project={project} variant="card" />
-                    </Link>
+                    <ProjectImage
+                      project={project}
+                      variant="card"
+                      className="transition-opacity group-hover:opacity-90"
+                    />
                     <p className="font-mono text-xs uppercase tracking-widest text-fg-muted">
                       <span>{frontmatter.role}</span>
                       <span aria-hidden="true"> · </span>
@@ -98,7 +106,7 @@ export default async function WorkIndexPage() {
                     <h2 className="font-display text-2xl font-medium tracking-tight text-fg sm:text-3xl">
                       <Link
                         href={`/work/${slug}`}
-                        className="group inline-flex items-baseline gap-2 hover:text-accent"
+                        className="inline-flex items-baseline gap-2 before:absolute before:inset-0 before:content-[''] hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-4 focus-visible:ring-offset-bg"
                       >
                         <span>{frontmatter.title}</span>
                         <span
@@ -126,7 +134,7 @@ export default async function WorkIndexPage() {
                     </ul>
 
                     {Object.keys(links).length > 0 ? (
-                      <p className="mt-5 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs uppercase tracking-widest">
+                      <p className="relative z-10 mt-5 flex flex-wrap gap-x-5 gap-y-2 font-mono text-xs uppercase tracking-widest">
                         {Object.entries(links).map(([key, href]) => (
                           <a
                             key={key}


### PR DESCRIPTION
Closes #74

## Summary

Each project card on `/work` was rendering two adjacent `<a>` elements pointing to the same case-study page — an image link with `aria-label="Open <Name>"` plus a text link `<Name> →` — producing 12 Tab stops (and 12 link-list entries for screen readers) on a page that should have 6.

Switch to the single-link / stretched-link pattern: the title `<Link>` is the only focusable element on the card, and it covers the entire card via a `before:absolute before:inset-0` overlay. The image area remains mouse-clickable but contributes nothing to the accessibility tree. External "live / repo / paper" links in the right column carry `relative z-10` so they stay clickable above the overlay.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Rendered HTML inspected via `curl http://localhost:3000/work`: exactly one `<a href="/work/<slug>">` per project card; no more `aria-label="Open <Name>"` image-link wrappers; title text (`<Name> →`) is the accessible name and is unique across cards.
- [ ] Manual: Tab through `/work` — each card consumes exactly one Tab stop (was two); focus ring lands around the title.
- [ ] Manual: VoiceOver rotor "Links" — each project listed once (was twice).
- [ ] Manual: clicking the image area still navigates (mouse-clickability preserved via the overlay).
- [ ] Manual: external project links in the right column still navigate to their `target="_blank"` destinations (z-10 keeps them above the overlay).