### PR TITLE
docs(dx): add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# CLAUDE.md
+
+Repo-scoped guidance for Claude Code sessions on `mattsears18.com`. Pointer-style — for the locked tech stack and rationale see [`docs/architecture.md`](./docs/architecture.md); for typography, palette, and layout tokens see [`docs/design.md`](./docs/design.md). Don't restate those here.
+
+## Stack
+
+Next.js 16 (App Router) + React 19 + TypeScript + Tailwind 3 + MDX, deployed on Vercel. Sentry wired via `@sentry/nextjs`. Node `>=22.0.0` (`.nvmrc` pins `24.15.0`). Package manager is **npm** — `package-lock.json` is the source of truth.
+
+## Content model
+
+- `content/posts/*.mdx` — blog posts, surfaced via [`lib/posts.ts`](./lib/posts.ts). Required frontmatter: `title`, `date`, `excerpt`. Optional: `tags`, `draft`.
+- `content/work/*.mdx` — portfolio projects, surfaced via [`lib/work.ts`](./lib/work.ts). Required frontmatter: `title`, `role`, `year`, `summary`, `tech[]`. Optional: `links`, `featured`, `image`, `imageAlt`. Year sort treats `"present"` as the current year; ties broken by title.
+- Both readers use `gray-matter` and live entirely at build time — no DB, no CMS.
+
+## Commands
+
+| Command            | What it does                                              |
+| ------------------ | --------------------------------------------------------- |
+| `npm run dev`      | Dev server on port 3000                                   |
+| `npm run build`    | Production build — run before pushing if you touched code |
+| `npm start`        | Serve the built site locally                              |
+| `npm run lint`     | ESLint via flat config (`eslint.config.mjs`)              |
+| `npx tsc --noEmit` | Type check (CI runs this — match it locally)              |
+| `npm run format`   | Prettier write across the repo                            |
+
+CI ([`.github/workflows/ci.yml`](./.github/workflows/ci.yml)) runs `npm ci` → `lint` → `tsc --noEmit` → `build` on every PR + push to `main`. Husky + lint-staged auto-format staged files on commit per [`.lintstagedrc.json`](./.lintstagedrc.json) — don't `--no-verify` to skip.
+
+## Conventions
+
+- **TypeScript everywhere.** Prefer Server Components; reach for `'use client'` only when an interactive surface needs it.
+- **Tailwind for styling**, not CSS modules. Design tokens (colors, fonts) are CSS custom properties in [`app/globals.css`](./app/globals.css) consumed via `tailwind.config.ts`. Add new long-form prose surfaces under the `.prose-post` component layer in `globals.css` — the Tailwind typography plugin is intentionally not installed.
+- **Single-purpose commits, Conventional Commits titles** (`feat(seo):`, `fix(a11y,web):`, `chore(dx):`, `docs(dx):`, `content(home):`). One concern per PR — open a new issue for drive-by bugs you spot.
+- **No `git add -A`.** Stage paths explicitly.
+- **shadcn/ui primitives are installed on-demand.** Don't pre-pull the catalog; each PR adds only what it uses.
+
+## Gotchas worth remembering
+
+- **Always define `.prose-post` styles when adding a new prose surface.** Without explicit styles MDX renders unstyled — see [#27](https://github.com/mattsears18/mattsears18.com/pull/27) for the symptom + fix pattern.
+- **iTerm screenshots crop the title bar.** Re-crop screenshots before committing them under `public/` (esp. `public/work/*.png`) — see [#28](https://github.com/mattsears18/mattsears18.com/pull/28).
+- **Work-card images fall back to the initial card if the public path is missing.** `lib/work.ts` strips `image` / `imageAlt` at read time when the referenced asset isn't on disk, so MDX authors can set the convention path eagerly and drop the PNG in later without a render regression. Don't fight this — drop the file in or leave the field unset.
+- **Year sort in `lib/work.ts` is end-year–based**, with `"present"` resolving to `new Date().getUTCFullYear()`. Active projects always lead. Don't normalize the human-readable year format.
+- **`rehype-pretty-code` is configured with `keepBackground: false`** so code-block backgrounds come from our design tokens, not the Shiki theme. If a new prose surface needs syntax highlighting, copy the `.prose-post pre` rules in `globals.css` — don't re-enable `keepBackground`.
+
+## Auto-merge
+
+Repo currently has `allow_auto_merge: false` at the repo settings level — `gh pr merge <M> --auto` will error. For trusted authors with admin perms, `gh pr merge <M> --merge --delete-branch` is the manual fallback after CI goes green. Don't try to flip the repo setting from inside a PR.
+
+## What not to touch
+
+- `.github/workflows/` — CI definitions are stable; bring repo-config changes through a separate issue.
+- `docs/architecture.md` / `docs/design.md` — these lock decisions deliberately. Raise a follow-up issue if a token needs revisiting rather than editing in-line during a feature PR.


### PR DESCRIPTION
Closes #64

## Summary

Adds a repo-scoped `CLAUDE.md` at the repo root — pointer/quickstart style. References `docs/architecture.md` and `docs/design.md` for the locked stack and design tokens rather than restating them. Covers what Claude sessions actually need every time: the stack version pins, the `content/posts` + `content/work` MDX model surfaced via `lib/posts.ts` / `lib/work.ts`, canonical commands, conventions, and the recurring gotchas worth keeping in working memory across parallel-worktree sessions.

51 lines, well under the ~120-line target.

## Test plan

- [x] `npx prettier --check CLAUDE.md` — passes
- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] Each acceptance criterion satisfied:
  - [x] `CLAUDE.md` exists at repo root
  - [x] Lists canonical dev/build/lint/typecheck commands
  - [x] Points to (does not duplicate) `docs/architecture.md` and `docs/design.md`
  - [x] Captures repo-specific gotchas (`.prose-post` styles, iTerm screenshot crops, work-image fallback, year-sort, `rehype-pretty-code` `keepBackground: false`)