### PR TITLE
chore(dx): add .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run build)",
+      "Bash(npm run dev)",
+      "Bash(npm run start)",
+      "Bash(npm test)",
+      "Bash(npx tsc:*)",
+      "Bash(npx prettier:*)",
+      "Bash(npx eslint:*)",
+      "Bash(npx next:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .shipyard/
+
+# Claude Code — committed: .claude/settings.json
+# Ignored: per-user override + orchestrator worktrees
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Closes #65

## Summary

Seed the repo's per-project Claude Code allowlist with the common safe reads (lint, build, dev, start, tsc, prettier, eslint, next, test). Eliminates the per-session permission prompt spam that stalls `/shipyard:do-work` workers and interactive Claude Code sessions.

Per-user overrides go in `.claude/settings.local.json` (gitignored). Orchestrator worktrees (`.claude/worktrees/`) are also gitignored so they don't get committed.

## Test plan

- [ ] `.claude/settings.json` is present at repo root and committed
- [ ] `.gitignore` excludes `.claude/settings.local.json` and `.claude/worktrees/`
- [ ] `npm run lint` passes (unaffected — config-only change)
- [ ] `npx tsc --noEmit` passes (unaffected — config-only change)
- [ ] CI green