### PR TITLE
fix(a11y,web): label focusable code blocks for screen readers

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,7 +1,83 @@
 import type { MDXComponents } from 'mdx/types';
+import type { ComponentPropsWithoutRef } from 'react';
+
+/*
+ * Human-readable language labels for screen-reader announcement of code blocks.
+ * `rehype-pretty-code` sets `data-language` from the fenced-code annotation
+ * (```ts → "ts", ```jsx → "jsx", etc.). Map the short token to a friendly name
+ * when one is known; otherwise pass the token through verbatim so unknown
+ * languages still produce a meaningful label.
+ *
+ * Pre-rendered `aria-label`s are stable across server/client, so this can stay
+ * a Server Component without any hydration concerns.
+ */
+const LANGUAGE_LABELS: Record<string, string> = {
+  bash: 'Bash',
+  css: 'CSS',
+  diff: 'Diff',
+  go: 'Go',
+  graphql: 'GraphQL',
+  html: 'HTML',
+  ini: 'INI',
+  java: 'Java',
+  js: 'JavaScript',
+  javascript: 'JavaScript',
+  json: 'JSON',
+  jsx: 'JSX',
+  md: 'Markdown',
+  markdown: 'Markdown',
+  mdx: 'MDX',
+  python: 'Python',
+  py: 'Python',
+  rb: 'Ruby',
+  ruby: 'Ruby',
+  rust: 'Rust',
+  sh: 'Shell',
+  shell: 'Shell',
+  sql: 'SQL',
+  svg: 'SVG',
+  swift: 'Swift',
+  toml: 'TOML',
+  ts: 'TypeScript',
+  typescript: 'TypeScript',
+  tsx: 'TSX',
+  xml: 'XML',
+  yaml: 'YAML',
+  yml: 'YAML',
+};
+
+/*
+ * Override the MDX `<pre>` renderer so the focusable code container
+ * (shiki/rehype-pretty-code adds `tabindex="0"` for keyboard scrolling)
+ * carries an accessible name. Without this, a Tab into the block announces
+ * only the raw code text, violating WCAG 2.1 AA 4.1.2 (Name, Role, Value).
+ *
+ * The label is derived from the `data-language` attribute that
+ * `rehype-pretty-code` writes onto the `<pre>` element. Fences without a
+ * language hint fall through to a generic "Code sample" label.
+ *
+ * See [#73](https://github.com/mattsears18/mattsears18.com/issues/73).
+ */
+function CodeBlockPre(props: ComponentPropsWithoutRef<'pre'>) {
+  // rehype-pretty-code (via shiki) emits `data-language` on the <pre>; in MDX
+  // / React this surfaces as a string-valued data attribute on the props bag.
+  const language = (props as Record<string, unknown>)['data-language'];
+  const languageKey = typeof language === 'string' ? language.toLowerCase() : '';
+  const languageLabel = LANGUAGE_LABELS[languageKey] ?? language;
+  const ariaLabel =
+    typeof languageLabel === 'string' && languageLabel.length > 0
+      ? `Code sample: ${languageLabel}`
+      : 'Code sample';
+
+  // Respect any aria-label the MDX author or upstream transformer already set —
+  // we only add one when it's missing.
+  const existingAriaLabel = props['aria-label'];
+  return <pre {...props} aria-label={existingAriaLabel ?? ariaLabel} />;
+}
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
+    pre: CodeBlockPre,
   };
 }


### PR DESCRIPTION
Closes #73

## Summary

`rehype-pretty-code` (via shiki) adds `tabindex="0"` to every `<pre>` so keyboard users can horizontally scroll long code samples — but the element had no accessible name. A screen-reader user who Tabbed into the block heard only raw code text character-by-character, failing WCAG 2.1 AA 4.1.2 (Name, Role, Value).

This PR overrides the MDX `<pre>` renderer in `mdx-components.tsx` to derive an `aria-label` from the `data-language` attribute that `rehype-pretty-code` emits onto the `<pre>` element. Known languages get a friendly label (`Code sample: TypeScript`); unknown languages pass through verbatim; fences without a language hint fall back to `Code sample`.

Implementation notes:

- Chose to override the `<pre>` MDX component (Option A from the issue) over post-processing in the rehype pipeline. The MDX-components override is the smallest possible change, keeps the rehype config untouched, and runs at render time so the label always reflects whatever `data-language` the upstream pipeline produced.
- Did not implement the "remove `tabindex` if the block doesn't overflow" branch from the issue's Option B — shiki adds the tabindex unconditionally, and detecting horizontal overflow is a runtime measurement that's not knowable at build time. Always providing the label satisfies the first two acceptance criteria and is the safe default: a focusable element should always have a name, even when scrolling isn't strictly needed.
- The override is hydration-safe — `data-language` is a stable build-time attribute, so the same label renders on both server and client.

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npm run lint` passes.
- [x] `npm run build` succeeds.
- [x] Manually verified via `next start` + `curl` that the rendered `<pre>` on `/blog/hello-from-the-new-site` now reads:
  `<pre tabindex="0" data-language="ts" data-theme="github-light github-dark" aria-label="Code sample: TypeScript">`
- [ ] (Reviewer) Re-run the audit's DevTools check on the deployed page — `document.querySelector('pre').getAttribute('aria-label')` should now return `"Code sample: TypeScript"` instead of `null`.