### PR TITLE
fix(seo,web): restore og:site_name on all routes via shared defaultOpenGraph

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from 'next/navigation';
 import { JsonLd } from '@/app/components/json-ld';
 import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatPostDate, getAllPosts, getPostBySlug } from '@/lib/posts';
-import { SITE_TITLE } from '@/lib/site';
+import { defaultOpenGraph, SITE_TITLE } from '@/lib/site';
 
 type Params = { slug: string };
 
@@ -25,6 +25,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
     authors: [{ name: SITE_TITLE }],
     alternates: { canonical },
     openGraph: {
+      ...defaultOpenGraph,
       title: post.frontmatter.title,
       description: post.frontmatter.excerpt,
       type: 'article',

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { JsonLd } from '@/app/components/json-ld';
 import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatPostDate, getAllPosts } from '@/lib/posts';
+import { defaultOpenGraph } from '@/lib/site';
 
 const BLOG_DESCRIPTION =
   'Writing on software engineering — systems, ops, and the work of leading teams that ship.';
@@ -13,6 +14,7 @@ export const metadata: Metadata = {
   description: BLOG_DESCRIPTION,
   alternates: { canonical: '/blog' },
   openGraph: {
+    ...defaultOpenGraph,
     title: 'Blog — Matt Sears',
     description: BLOG_DESCRIPTION,
     url: '/blog',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,14 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
-import { SITE_TAGLINE, SITE_TITLE } from '@/lib/site';
+import { defaultOpenGraph, SITE_TAGLINE, SITE_TITLE } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: { absolute: SITE_TITLE },
   description: SITE_TAGLINE,
   alternates: { canonical: '/' },
   openGraph: {
+    ...defaultOpenGraph,
     title: SITE_TITLE,
     description: SITE_TAGLINE,
     url: '/',

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -6,7 +6,7 @@ import { JsonLd } from '@/app/components/json-ld';
 import { ProjectImage } from '@/app/components/project-image';
 import { breadcrumbListSchema } from '@/lib/json-ld';
 import { formatLinkLabel, getAllProjects, getProjectBySlug } from '@/lib/work';
-import { SITE_TITLE } from '@/lib/site';
+import { defaultOpenGraph, SITE_TITLE } from '@/lib/site';
 
 type Params = { slug: string };
 
@@ -26,6 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<Params> }):
     authors: [{ name: SITE_TITLE }],
     alternates: { canonical },
     openGraph: {
+      ...defaultOpenGraph,
       title: project.frontmatter.title,
       description: project.frontmatter.summary,
       type: 'article',

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { JsonLd } from '@/app/components/json-ld';
 import { ProjectImage } from '@/app/components/project-image';
 import { breadcrumbListSchema } from '@/lib/json-ld';
+import { defaultOpenGraph } from '@/lib/site';
 import { formatLinkLabel, getAllProjects } from '@/lib/work';
 
 const WORK_DESCRIPTION =
@@ -14,6 +15,7 @@ export const metadata: Metadata = {
   description: WORK_DESCRIPTION,
   alternates: { canonical: '/work' },
   openGraph: {
+    ...defaultOpenGraph,
     title: 'Work — Matt Sears',
     description: WORK_DESCRIPTION,
     url: '/work',

--- a/lib/site.ts
+++ b/lib/site.ts
@@ -8,3 +8,23 @@ export const SITE_TITLE = 'Matt Sears';
 export const SITE_DESCRIPTION =
   'Matt Sears — software engineer with a civil engineering PhD. Lead engineer at SalesRiver, board member at Enrich, and builder of Shipyard and Lightwork on the side.';
 export const SITE_TAGLINE = 'Software engineer with a civil engineering PhD.';
+
+/**
+ * Default Open Graph fields that must appear on every route. The Next.js
+ * App Router does NOT shallow-merge `openGraph` objects across the layout/
+ * page boundary — a page-level `openGraph` block replaces the root layout's
+ * `openGraph` entirely, dropping `siteName` / `locale` / etc. (see #68).
+ *
+ * Spread this constant into every page-level `openGraph` so the site-wide
+ * fields are preserved alongside route-specific overrides:
+ *
+ *   openGraph: {
+ *     ...defaultOpenGraph,
+ *     title: 'Post title',
+ *     ...
+ *   }
+ */
+export const defaultOpenGraph = {
+  siteName: SITE_TITLE,
+  locale: 'en_US',
+} as const;


### PR DESCRIPTION
Closes #68

## Summary

- Next.js App Router metadata merging does NOT shallow-merge `openGraph` across the layout/page boundary — every page-level `openGraph` block (in `app/page.tsx`, `app/blog/page.tsx`, `app/work/page.tsx`, `app/blog/[slug]/page.tsx`, `app/work/[slug]/page.tsx`) was replacing the root layout's `openGraph` wholesale, dropping `siteName`.
- Added a shared `defaultOpenGraph` constant to `lib/site.ts` (siteName + locale) per the issue's suggested approach, and spread it into every page-level `openGraph` block so route-specific overrides preserve the site-wide fields.
- The page-level `opengraph-image.tsx` route handlers (which use `metadata.openGraph` shallow-replace mechanics for the image; see `app/work/[slug]/opengraph-image.tsx` comments and #55) are untouched — that mechanism is separate from the `siteName` propagation.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/`
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/blog`
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/work`
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/blog/hello-from-the-new-site`
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/work/lightwork`
- [x] `<meta property="og:site_name" content="Matt Sears">` rendered on `/work/shipyard`
- [x] `og:locale="en_US"` also propagates (bonus — was implicit on root only)