### PR TITLE
fix(seo,web): home page meta description — use full SITE_DESCRIPTION

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,23 +2,23 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
-import { defaultOpenGraph, SITE_TAGLINE, SITE_TITLE } from '@/lib/site';
+import { defaultOpenGraph, SITE_DESCRIPTION, SITE_TITLE } from '@/lib/site';
 
 export const metadata: Metadata = {
   title: { absolute: SITE_TITLE },
-  description: SITE_TAGLINE,
+  description: SITE_DESCRIPTION,
   alternates: { canonical: '/' },
   openGraph: {
     ...defaultOpenGraph,
     title: SITE_TITLE,
-    description: SITE_TAGLINE,
+    description: SITE_DESCRIPTION,
     url: '/',
     type: 'website',
   },
   twitter: {
     card: 'summary_large_image',
     title: SITE_TITLE,
-    description: SITE_TAGLINE,
+    description: SITE_DESCRIPTION,
   },
 };
 


### PR DESCRIPTION
Closes #66

## Summary

The home page (`/`) was using `SITE_TAGLINE` (47 chars) as its `<meta name="description">` instead of `SITE_DESCRIPTION` (164 chars). Swap `description`, `og:description`, and `twitter:description` in `app/page.tsx` to `SITE_DESCRIPTION` so the home page surfaces the SalesRiver role, Enrich board work, and Shipyard/Lightwork side projects in SERPs.

The root layout (`app/layout.tsx`) already uses `SITE_DESCRIPTION` as the fallback — the page-level override was the only thing shortening the home description.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes (no warnings)
- [ ] After deploy, view-source on `https://mattsears18.com/` and confirm `<meta name="description">` is the 164-char `SITE_DESCRIPTION` string
- [ ] Confirm `og:description` and `twitter:description` on the home page match
- [ ] Confirm no other route's description changed (`SITE_DESCRIPTION` was already the fallback for non-home routes)

## Notes

`SITE_DESCRIPTION` is 164 chars, slightly above the 120–160 target in the acceptance criteria. The literal Google SERP truncation is ~155 chars, so the trailing 9 chars (\` on the side.\`) get truncated in search results — not a defect, just a minor copy nit. A follow-up issue could tighten the constant; that's out of scope here since it's shared with the layout/RSS surfaces.