### PR TITLE
docs(dx): add MIT LICENSE — make repo licensing stance explicit

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Sears
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #59

## Summary

Adds a top-level `LICENSE` file (MIT, Copyright (c) 2026 Matt Sears) so the repo's licensing stance is explicit rather than the default "all rights reserved." Resolves the `dx` audit finding that flagged the missing license.

A single repo-wide MIT license keeps the code-vs-content split unambiguous (everything in the repo is MIT) without introducing a second license file or per-directory carve-out, which the issue body listed as an acceptable path.

## Test plan

- [ ] `LICENSE` file exists at repo root (verifies acceptance criterion 1).
- [ ] License terms apply uniformly across code and content — single MIT license, no per-directory carve-out (verifies acceptance criterion 2).
- [ ] CI green (lint / tsc / build unaffected — repo addition only).