### PR TITLE
docs(work): fix drifted .png examples — match real .jpg screenshots on disk

### DIFF
--- a/lib/work.ts
+++ b/lib/work.ts
@@ -14,7 +14,7 @@ import matter from 'gray-matter';
  * (paper / video / case-study) without re-touching this type — the index +
  * detail pages render whatever keys are present using `formatLinkLabel`.
  *
- * `image` is a public-root path like `/work/lightwork.png`. If the file is
+ * `image` is a public-root path like `/work/lightwork.jpg`. If the file is
  * missing from `public/`, `getAllProjects` strips the field at read time so
  * the UI falls back to the generated initial-card instead of rendering a
  * broken <Image>. This lets MDX authors set the convention path eagerly and

--- a/public/work/README.md
+++ b/public/work/README.md
@@ -4,15 +4,15 @@ Drop project screenshots into this directory using the slug from `content/work/<
 
 ```
 public/work/
-├── cdot-duration-predictor.png
-├── express-delphi.png
-├── lightwork.png
-├── nccer-sso.png
+├── cdot-duration-predictor.jpg
+├── express-delphi.jpg
+├── lightwork.jpg
+├── nccer-sso.jpg
 ├── shipyard.png
-└── visual-eyes.png
+└── visual-eyes.jpg
 ```
 
-The path in each project's frontmatter (`image: /work/<slug>.png`) is already wired up. When the file lands in this directory, `lib/work.ts` picks it up and the index card + detail page hero render it instead of the fallback initial-card.
+The path in each project's frontmatter (`image: /work/<slug>.{png,jpg}`) is already wired up — pick the extension that matches the file you commit. When the file lands in this directory, `lib/work.ts` picks it up and the index card + detail page hero render it instead of the fallback initial-card.
 
 ## Recommended specs
 


### PR DESCRIPTION
Closes #48

## Summary

The directory-tree example in `public/work/README.md` and the JSDoc example in `lib/work.ts` both showed `.png` filenames, but the committed screenshots are `.jpg` (except `shipyard.png`). A contributor reading either would assume the convention is PNG-only, contradicting the README's own "PNG for UI screenshots, JPG for photography" recommendation and what `content/work/*.mdx` frontmatter actually points at.

- `public/work/README.md` — directory tree now reflects 5 `.jpg`s + `shipyard.png` on disk; updated surrounding prose to mention `{png,jpg}` so the format choice tracks the recommended-specs section.
- `lib/work.ts:17` — JSDoc example path changed from `/work/lightwork.png` to `/work/lightwork.jpg` so it agrees with the real `lightwork.mdx` frontmatter.

## Test plan

- [x] `ls public/work/` matches the new directory tree in the README (5 jpg + 1 png).
- [x] `lib/work.ts` JSDoc example (`/work/lightwork.jpg`) resolves to an existing file.
- [x] `content/work/*.mdx` `image:` paths still match files on disk — no regression (verified by `grep -nE "^image:" content/work/*.mdx` against `ls public/work/`).