### PR TITLE
docs(dx): document every env var the app reads in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
-# Sentry error tracking — see #43, sentry.server.config.ts, instrumentation-client.ts.
+# Example environment file. Copy to .env.local for local development:
 #
+#   cp .env.example .env.local
+#
+# .env.local is gitignored (.env*.local pattern); .env is gitignored too.
+# This file (.env.example) is committed — it documents the env-var surface
+# without carrying any real values. Keep placeholders empty.
+#
+# Discovery: grep -rn "process.env\." . --include="*.ts" --include="*.tsx" \
+#   --include="*.js" --include="*.mjs" | grep -v node_modules | grep -v ".next"
+
+# -----------------------------------------------------------------------------
+# Sentry — error tracking (runtime)
+# -----------------------------------------------------------------------------
 # Both vars hold the same DSN value (Sentry DSNs are designed to be public).
 # The split is to keep the env-var surface explicit:
 #   - SENTRY_DSN              → server + edge runtimes (sentry.server.config.ts,
@@ -11,5 +23,63 @@
 # dev box; the init blocks soft-fail when the DSN is missing.
 #
 # In Vercel project env vars: set both for Production and Preview environments.
+# See #43 for the original wire-up.
 SENTRY_DSN=
 NEXT_PUBLIC_SENTRY_DSN=
+
+# -----------------------------------------------------------------------------
+# Sentry — source map upload (build-time)
+# -----------------------------------------------------------------------------
+# Consumed by withSentryConfig in next.config.js to associate built JS bundles
+# with Sentry releases and upload source maps. Only matters at `next build`
+# time; local `npm run dev` doesn't touch these.
+#
+# Set in Vercel project env vars (or your CI provider) so production builds
+# can upload source maps. Leave unset locally — builds still succeed without
+# them, you just won't get symbolicated stack traces for that build.
+#
+# SENTRY_AUTH_TOKEN is a secret — get one from Sentry's "Organization Auth
+# Tokens" page. Never commit a real value.
+SENTRY_ORG=
+SENTRY_PROJECT=
+SENTRY_AUTH_TOKEN=
+
+# -----------------------------------------------------------------------------
+# Vercel-injected (auto-set in deployed environments)
+# -----------------------------------------------------------------------------
+# Vercel sets these automatically on Preview and Production deploys; locally
+# they default to undefined. Only set them in .env.local if you want to
+# simulate a deployed environment from your dev box (e.g., hide the Vercel
+# toolbar by setting VERCEL_ENV=production, or test Sentry's
+# production-environment tagging).
+#
+# Consumers:
+#   - VERCEL_ENV               → app/layout.tsx (toolbar gating), proxy.ts
+#                               (sampled tracing), sentry.{server,edge}.config.ts
+#                               (environment tag + traces sample rate).
+#   - NEXT_PUBLIC_VERCEL_ENV   → instrumentation-client.ts (client-side Sentry
+#                               environment + traces sample rate). Inlined into
+#                               the browser bundle at build time.
+#
+# Valid values: development | preview | production
+VERCEL_ENV=
+NEXT_PUBLIC_VERCEL_ENV=
+
+# -----------------------------------------------------------------------------
+# Runtime-injected (Node.js / Next.js / CI runner)
+# -----------------------------------------------------------------------------
+# Set automatically by Node, Next.js, and GitHub Actions / Vercel build runners.
+# You normally don't override these — listed here for documentation only.
+#
+# Consumers:
+#   - NODE_ENV       → proxy.ts, instrumentation-client.ts,
+#                      sentry.{server,edge}.config.ts. Set by `next dev` to
+#                      "development" and by `next build` / `next start` to
+#                      "production".
+#   - NEXT_RUNTIME   → instrumentation.ts. Set by Next.js to "nodejs" or "edge"
+#                      depending on which runtime is loading the file.
+#   - CI             → next.config.js (Sentry plugin verbosity). Set to "1" /
+#                      "true" by GitHub Actions and most CI providers.
+NODE_ENV=
+NEXT_RUNTIME=
+CI=

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,8 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
-# local env files
+# local env files — .env.example is committed (placeholder values only).
+.env
 .env*.local
 
 # vercel


### PR DESCRIPTION
Closes #54

## Summary

- Expand `.env.example` beyond the Sentry DSN pair (the only thing previously documented, from #43) to cover every variable the app actually reads. Discovery: `grep -rn "process.env\." . --include="*.ts" --include="*.tsx" --include="*.js" --include="*.mjs"` across `app/`, `lib/`, `next.config.*`, `proxy.ts`, `instrumentation*.ts`, and `sentry.*.config.ts`.
- Group entries by purpose with one comment block each: **Sentry runtime** (`SENTRY_DSN`, `NEXT_PUBLIC_SENTRY_DSN`), **Sentry build-time** (`SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` — consumed by `withSentryConfig` for source-map upload), **Vercel-injected** (`VERCEL_ENV`, `NEXT_PUBLIC_VERCEL_ENV`), **Runtime-injected** (`NODE_ENV`, `NEXT_RUNTIME`, `CI`). All placeholders are empty — no secrets, no real values.
- Ignore bare `.env` in `.gitignore`. `.env*.local` was already covered, but `.env` itself was not — a developer who `cp .env.example .env` and fills in a real `SENTRY_AUTH_TOKEN` could otherwise commit it.

## Test plan

- [x] `.env.example` exists at repo root.
- [x] Lists every env var the code reads — verified against `grep -rn "process.env\."` discovery.
- [x] All values are placeholders (empty `=`); no real secrets.
- [x] `.env` and `.env.local` confirmed gitignored (`git check-ignore -v .env .env.local`).
- [x] `.env.example` confirmed NOT gitignored.