### PR TITLE
docs(dx): add GitHub issue templates (#57)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Something on the site is broken or behaves unexpectedly.
+title: "bug: <short description>"
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: When I clicked the RSS link in the footer, the page 404'd.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps so the bug can be reproduced reliably.
+      placeholder: |
+        1. Visit https://mattsears18.com/blog
+        2. Click the first post
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: The page should render with code blocks styled by .prose-post.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Code blocks appear unstyled (default browser monospace, no background).
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Browser / device
+      description: Browser + version, OS, mobile vs desktop. Skip if not relevant.
+      placeholder: Safari 17.4 on macOS 14, desktop
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Screenshots, console errors, links to related issues.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request
+description: Suggest an enhancement, new content, or a content correction.
+title: "feat: <short description>"
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What's missing or could be better? Skip if this is purely a "nice to have."
+      placeholder: The blog index doesn't show post dates, so I can't tell which posts are recent.
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: What should change? Be specific where you can.
+      placeholder: Add a published date next to each post title on /blog.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you'd skip them.
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Mockups, links, references.


### PR DESCRIPTION
Closes #57

## Summary

Add form-style YAML issue templates under `.github/ISSUE_TEMPLATE/` so human- and agent-filed issues land with a predictable shape:

- `bug_report.yml` — repro steps, expected vs. actual, browser/device. Labels: `bug`, `needs-triage`.
- `feature_request.yml` — feature requests, content corrections, blog post ideas (fits the content-heavy nature of this site). Labels: `enhancement`, `needs-triage`.
- `config.yml` — `blank_issues_enabled: false` so all human-filed issues use a template.

Uses GitHub's form-style YAML schema (not legacy markdown). Kept short — this is a personal repo.

## Test plan

- [ ] `.github/ISSUE_TEMPLATE/` contains at least one template (verified: 3 files added).
- [ ] Bug template includes repro steps and expected/actual sections (verified in `bug_report.yml`).
- [ ] Templates parse as valid YAML (verified locally with `js-yaml`).
- [ ] Label arrays only reference labels that already exist on the repo (`bug`, `enhancement`, `needs-triage` — confirmed via `gh label list`).