### PR TITLE
docs(dx): add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Closes #<issue-number> -->
+
+## Summary
+
+<!-- 1-2 sentences on what this PR does and why. -->
+
+## Test plan
+
+- [ ] <!-- How was this verified? -->
+
+## Screenshots / preview link
+
+<!-- For visual changes: before/after screenshots or the Vercel preview URL. -->


### PR DESCRIPTION
Closes #56

## Summary

Add `.github/pull_request_template.md` so every PR (human- or agent-filed) starts with a Summary, Test plan, and a screenshot/preview prompt for visual changes. Kept short to match the personal-repo tone; uses the lowercase filename so GitHub picks it up regardless of case-sensitivity quirks, and leaves a `Closes #<issue-number>` reminder as an HTML comment near the top.

## Test plan

- [x] `.github/pull_request_template.md` exists at the expected path.
- [x] Template prompts for Summary, Test plan, and Screenshots/preview link (matches the audit acceptance criteria).
- [ ] After merge, the "New PR" UI on GitHub auto-fills the body with the template (verified manually on the next PR opened against this repo).