### PR TITLE
feat(privacy,compliance): add /privacy notice disclosing Vercel as hosting processor

### DIFF
--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -1,7 +1,14 @@
+import Link from 'next/link';
+
 /**
- * Page footer. Single line of attribution + source link, fg-muted.
- * Kept intentionally bare — no nav repetition, no social row, no copyright
- * year ceremony. Matches the editorial restraint called out in design.md.
+ * Page footer. Single line of attribution + source link + privacy link,
+ * fg-muted. Kept intentionally bare — no nav repetition, no social row, no
+ * copyright year ceremony. Matches the editorial restraint called out in
+ * design.md.
+ *
+ * The Privacy link is the visible disclosure required by the privacy notice
+ * (see #44). Internal `next/link` because /privacy is a same-origin route;
+ * the GitHub link stays external (target="_blank") because it points off-site.
  */
 export function SiteFooter() {
   return (
@@ -17,6 +24,13 @@ export function SiteFooter() {
           >
             GitHub
           </a>
+          .{' '}
+          <Link
+            href="/privacy"
+            className="text-fg-muted underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
+          >
+            Privacy
+          </Link>
           .
         </p>
       </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,181 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { JsonLd } from '@/app/components/json-ld';
+import { breadcrumbListSchema } from '@/lib/json-ld';
+import { defaultOpenGraph } from '@/lib/site';
+
+const PRIVACY_DESCRIPTION =
+  'How visitor data is handled on mattsears18.com — short, factual, and limited to what hosting infrastructure requires.';
+
+export const metadata: Metadata = {
+  title: 'Privacy',
+  description: PRIVACY_DESCRIPTION,
+  alternates: { canonical: '/privacy' },
+  openGraph: {
+    ...defaultOpenGraph,
+    title: 'Privacy — Matt Sears',
+    description: PRIVACY_DESCRIPTION,
+    url: '/privacy',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Privacy — Matt Sears',
+    description: PRIVACY_DESCRIPTION,
+  },
+};
+
+/**
+ * `/privacy` — short, factual disclosure of what visitor data flows through
+ * the site's hosting infrastructure. See #44.
+ *
+ * Scope intentionally narrow: this is a personal/portfolio site with no
+ * analytics, no cookies, no accounts, and no contact form on-site. The only
+ * data that touches anything is the inbound HTTP request itself, which
+ * Vercel's CDN logs as part of normal operation. The notice exists so a
+ * visitor can read what's happening end-to-end without having to infer it
+ * from the Vercel and GitHub privacy policies.
+ *
+ * NOT a substitute for a formal Privacy Policy if the site ever grows
+ * commercial scope (newsletter, paid product, account system). At that point
+ * this page gets replaced with something a lawyer reviewed; in the meantime
+ * disclosing what does happen is better than disclosing nothing.
+ */
+export default function PrivacyPage() {
+  return (
+    <article className="mx-auto max-w-reading py-16 sm:py-20">
+      <JsonLd
+        schema={breadcrumbListSchema([
+          { name: 'Home', path: '/' },
+          { name: 'Privacy', path: '/privacy' },
+        ])}
+      />
+
+      <header className="mb-12 sm:mb-16">
+        <p className="mb-4 font-mono text-xs uppercase tracking-widest text-fg-muted">Privacy</p>
+        <h1 className="font-display text-4xl font-medium tracking-tight text-fg sm:text-5xl">
+          Privacy
+        </h1>
+        <p className="mt-4 max-w-xl text-base leading-relaxed text-fg-muted">
+          What happens to your data when you visit this site — short, factual, and limited to what
+          hosting infrastructure requires.
+        </p>
+      </header>
+
+      <div className="prose-post">
+        <h2>What data this site collects directly</h2>
+        <p>
+          Nothing. There are no analytics scripts, no cookies, no tracking pixels, no contact form,
+          and no accounts. Visiting any page sends no data to me beyond the HTTP request itself
+          (described below).
+        </p>
+
+        <h2>What data the hosting infrastructure processes</h2>
+        <p>
+          The site is hosted on <a href="https://vercel.com">Vercel</a>, which operates the content
+          delivery network (CDN) and runtime that serves every request. As part of normal
+          infrastructure operation, Vercel processes the data that&apos;s inherent to any HTTP
+          request:
+        </p>
+        <ul>
+          <li>your IP address</li>
+          <li>the URL you requested</li>
+          <li>the time of the request</li>
+          <li>your browser&apos;s user-agent string</li>
+          <li>the HTTP referrer (the page you came from, if any)</li>
+        </ul>
+        <p>
+          Vercel is the data processor for this information; I am the controller. Their handling is
+          governed by{' '}
+          <a
+            href="https://vercel.com/legal/privacy-policy"
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            Vercel&apos;s privacy policy
+          </a>{' '}
+          and{' '}
+          <a
+            href="https://vercel.com/legal/dpa"
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            data processing addendum
+          </a>
+          .
+        </p>
+
+        <h2>Cookies</h2>
+        <p>
+          The site sets no cookies. If a future feature requires them (for example, a comment
+          system, a contact form, or analytics) this page will be updated before that feature ships.
+        </p>
+
+        <h2>Error monitoring</h2>
+        <p>
+          Client-side and server-side errors are reported to <a href="https://sentry.io">Sentry</a>{' '}
+          to help me find and fix bugs. Sentry receives the error itself (stack trace, browser
+          version, the URL that triggered it) along with the IP address that initiated the request.
+          Sentry is also a data processor for this site; their handling is governed by{' '}
+          <a
+            href="https://sentry.io/privacy/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            Sentry&apos;s privacy policy
+          </a>
+          .
+        </p>
+
+        <h2>External links</h2>
+        <p>
+          The site links out to GitHub, LinkedIn, and a small handful of other services. Once you
+          follow a link, the destination&apos;s own privacy policy applies — I have no visibility
+          into or control over how those services handle your visit.
+        </p>
+
+        <h2>Requesting deletion</h2>
+        <p>
+          If you&apos;d like Vercel&apos;s or Sentry&apos;s log entries for your visits removed,
+          email me at{' '}
+          <a
+            href="mailto:matt@mksolutionsky.com"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            matt@mksolutionsky.com
+          </a>{' '}
+          and I&apos;ll forward the request to the relevant processor. Retention is short by default
+          (typically a few weeks for routine CDN logs), so most data ages out on its own.
+        </p>
+
+        <h2>Updates to this page</h2>
+        <p>
+          The site&apos;s source is{' '}
+          <a
+            href="https://github.com/mattsears18/mattsears18.com"
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            on GitHub
+          </a>{' '}
+          — any change to this page is in the commit history. There&apos;s no separate &quot;last
+          updated&quot; date because the git log is authoritative.
+        </p>
+      </div>
+
+      <footer className="mt-20 border-t border-border pt-8">
+        <Link
+          href="/"
+          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+        >
+          ← Back home
+        </Link>
+      </footer>
+    </article>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -13,6 +13,7 @@ import { getAllProjects } from '@/lib/work';
  *   - `/blog/:slug`   every published post      (lastModified = frontmatter date)
  *   - `/work`         portfolio index           (changeFrequency: monthly)
  *   - `/work/:slug`   every project detail page (changeFrequency: yearly)
+ *   - `/privacy`      privacy notice            (changeFrequency: yearly)
  *
  * Project frontmatter has no `date` field — projects are evergreen — so we
  * use `now` for project lastModified. Acceptable: search engines mostly use
@@ -48,6 +49,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: now,
       changeFrequency: 'monthly',
       priority: 0.8,
+    },
+    {
+      url: `${SITE_URL}/privacy`,
+      lastModified: now,
+      changeFrequency: 'yearly',
+      priority: 0.3,
     },
   ];
 


### PR DESCRIPTION
Closes #44

## Summary

Adds a `/privacy` route with a short, factual privacy notice and links it from the site footer. The notice discloses:

- **No first-party data collection** — no analytics scripts, no cookies, no tracking pixels, no accounts, no contact form on-site.
- **Vercel as hosting data processor** — IP, request URL, timestamp, user-agent, and referrer are processed by Vercel as part of normal CDN operation. Links out to Vercel's privacy policy and DPA.
- **Sentry as error-monitoring data processor** — error reports include the stack trace, browser version, request URL, and originating IP. Disclosed because the codebase already wires `@sentry/nextjs` (see `instrumentation.ts`, `sentry.*.config.ts`); not mentioning it would understate the data footprint.
- **Cookies** — none set; the page commits to updating before any are added.
- **Deletion contact** — `matt@mksolutionsky.com` to forward log-removal requests to processors.

Implemented as `app/privacy/page.tsx` (App Router Server Component) rather than a top-level `PRIVACY.md` because the issue acceptance criteria require the notice to be reachable from the site footer — a markdown file in the repo root isn't a routable visitor-facing page. Follows the same `<JsonLd> + breadcrumb + .prose-post` pattern as `/blog` and `/work`.

Footer link added as an internal `<Link href="/privacy">` (same-origin route) alongside the existing GitHub source link. Sitemap updated to include `/privacy` so crawlers can index it.

## What's NOT in this PR (and why)

- **`Referrer-Policy` header.** Already set to `strict-origin-when-cross-origin` in `next.config.js` line 26 (from #38). Acceptance criterion 4 was already satisfied.
- **`Permissions-Policy` header.** Already set in `next.config.js` line 27 (from #38). The audit body's "optionally bundle" suggestion is already in production.
- **Modifying `.github/workflows/` or branch protection.** Per `CLAUDE.md` "What not to touch."
- **Tightening any other headers.** Out of scope for this PR — file a follow-up issue if `interest-cohort=()` or other Privacy Sandbox opt-outs are needed.

## Test plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — `/privacy` shows up in the route table (server-rendered `ƒ` per the pattern used by other content routes).
- [x] `npm run format:check` — clean for the three files this PR touches (pre-existing warnings on unrelated `.github/` YAML files are not addressed here).
- [ ] After merge: visit `https://mattsears18.com/privacy` and confirm the page renders with breadcrumb JSON-LD, that the footer "Privacy" link is visible on every page, and that `/sitemap.xml` includes the new URL.