### PR TITLE
chore(dx): add Makefile with canonical workflow targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help setup install dev build start lint typecheck format format-check verify clean
+
+# Default target: print available targets.
+help:
+	@echo "Available targets:"
+	@echo "  setup         Install dependencies (npm ci — clean, lockfile-driven)"
+	@echo "  install       Alias for setup"
+	@echo "  dev           Start the Next.js dev server on port 3000"
+	@echo "  build         Production build (next build)"
+	@echo "  start         Serve the production build locally"
+	@echo "  lint          ESLint via flat config"
+	@echo "  typecheck     Run tsc --noEmit"
+	@echo "  format        Prettier write across the repo"
+	@echo "  format-check  Prettier check (no writes)"
+	@echo "  verify        lint + typecheck + build (matches CI)"
+	@echo "  clean         Remove build artifacts and node_modules"
+
+setup:
+	npm ci
+
+install: setup
+
+dev:
+	npm run dev
+
+build:
+	npm run build
+
+start:
+	npm start
+
+lint:
+	npm run lint
+
+typecheck:
+	npx tsc --noEmit
+
+format:
+	npm run format
+
+format-check:
+	npm run format:check
+
+# Canonical "is this checkout green?" — mirrors .github/workflows/ci.yml.
+verify: lint typecheck build
+
+clean:
+	rm -rf .next out node_modules

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ Open [http://localhost:3000](http://localhost:3000).
 | `npm start`     | Serve the production build locally    |
 | `npm run lint`  | ESLint via `next lint`                |
 
+A [`Makefile`](./Makefile) wraps these as one-liners for both humans and `/shipyard:do-work` agents:
+
+| Command          | What it does                                        |
+| ---------------- | --------------------------------------------------- |
+| `make help`      | List all available targets                          |
+| `make setup`     | `npm ci` — clean, lockfile-driven install           |
+| `make dev`       | Dev server on port 3000                             |
+| `make build`     | Production build                                    |
+| `make lint`      | ESLint                                              |
+| `make typecheck` | `tsc --noEmit`                                      |
+| `make verify`    | lint + typecheck + build — canonical "is it green?" |
+| `make clean`     | Remove `.next/`, `out/`, and `node_modules/`        |
+
+`make verify` mirrors [`.github/workflows/ci.yml`](./.github/workflows/ci.yml) — run it before pushing if you touched code.
+
 ## Deployment
 
 Vercel handles deploys. Pushes to `main` trigger production; every PR gets a preview URL.


### PR DESCRIPTION
Closes #60

## Summary

Adds a `Makefile` at the repo root that wraps the existing npm scripts as one-liners. Gives both humans and `/shipyard:do-work` agents a single canonical "bring this checkout to a green state" target — primarily `make verify` (lint + typecheck + build), which mirrors `.github/workflows/ci.yml`.

Targets: `help` (default), `setup` / `install`, `dev`, `build`, `start`, `lint`, `typecheck`, `format`, `format-check`, `verify`, `clean`. Skipped `test` — repo has no `npm test` script.

README updated with a Makefile-targets table alongside the existing npm-scripts table.

## Test plan

- [x] `make help` lists all targets
- [x] `make setup` runs `npm ci` cleanly
- [x] `make verify` (lint + typecheck + build) passes locally — mirrors CI
- [ ] CI passes on this PR