### PR TITLE
fix(a11y): add default underline to inline accent links

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,11 +75,17 @@
     @apply mt-4;
   }
 
+  /*
+   * Inline links carry a default underline so they're distinguishable
+   * without relying on color alone (WCAG 1.4.1 / Lighthouse
+   * link-in-text-block). Subtle accent-tinted decoration at rest;
+   * full-strength accent on hover. See issue #31.
+   */
   .prose-post a {
-    @apply text-accent underline-offset-4;
+    @apply text-accent underline decoration-accent/40 underline-offset-4;
   }
   .prose-post a:hover {
-    @apply underline;
+    @apply decoration-accent;
   }
 
   .prose-post ul {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
                 href="https://www.enrichky.com/"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent underline-offset-4 hover:underline"
+                className="text-accent underline decoration-accent/40 underline-offset-4 hover:decoration-accent"
               >
                 Enrich
               </a>


### PR DESCRIPTION
Closes #31

## Summary

Lighthouse's `link-in-text-block` audit flagged the inline "Enrich" link in the homepage About paragraph for being distinguishable by color alone — accent-tinted text with no underline at rest violates WCAG 1.4.1. The `.prose-post a` rule in `app/globals.css` had the same shape (accent color + `underline-offset-4` but only `hover:underline`), so blog posts and work case studies inherited the same issue.

Both surfaces now carry a default underline at rest with a subtle `decoration-accent/40` tint that intensifies to full `decoration-accent` on hover — a non-color visual indicator that satisfies the audit without changing the palette. CTA-style links elsewhere on the homepage (the `→`-suffixed Blog / GitHub / LinkedIn links and the footer's pre-underlined links) already carry non-color visual indicators and are unchanged.

## Test plan

- [ ] `npm run lint` clean (ran locally — clean).
- [ ] `npx tsc --noEmit` clean (ran locally — clean).
- [ ] `npm run build` succeeds (ran locally — succeeds).
- [ ] After merge + Vercel deploy, re-run a Lighthouse audit against the homepage and confirm `link-in-text-block` passes (acceptance criterion from the issue).
- [ ] Visual check: the "Enrich" link in the homepage About section is underlined at rest; the underline color is a muted accent tint and intensifies on hover.
- [ ] Visual check: a blog post body's inline link (e.g., the test post at `/blog/...`) shows the same underline pattern.