### PR TITLE
fix(a11y,web): meet 44px tap target minimum for header + footer interactive elements

### DIFF
--- a/app/components/site-footer.tsx
+++ b/app/components/site-footer.tsx
@@ -18,7 +18,7 @@ export function SiteFooter() {
           Built by Matt Sears. View source on{' '}
           <a
             href="https://github.com/mattsears18/mattsears18.com"
-            className="text-fg-muted underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
+            className="inline-flex min-h-[44px] items-center text-fg-muted underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
             target="_blank"
             rel="noreferrer"
           >
@@ -27,7 +27,7 @@ export function SiteFooter() {
           .{' '}
           <Link
             href="/privacy"
-            className="text-fg-muted underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
+            className="inline-flex min-h-[44px] items-center text-fg-muted underline decoration-border underline-offset-4 hover:text-accent hover:decoration-accent"
           >
             Privacy
           </Link>

--- a/app/components/site-header.tsx
+++ b/app/components/site-header.tsx
@@ -15,20 +15,20 @@ export function SiteHeader() {
       <div className="mx-auto flex h-16 max-w-container items-center justify-between px-6 sm:px-12">
         <Link
           href="/"
-          className="font-display text-base font-medium tracking-tight text-fg hover:text-accent"
+          className="inline-flex min-h-[44px] items-center font-display text-base font-medium tracking-tight text-fg hover:text-accent"
         >
           Matt Sears
         </Link>
         <nav aria-label="Primary" className="flex items-center gap-1 sm:gap-2">
           <Link
             href="/work"
-            className="rounded-md px-3 py-2 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+            className="inline-flex min-h-[44px] items-center rounded-md px-3 py-3 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
           >
             Work
           </Link>
           <Link
             href="/blog"
-            className="rounded-md px-3 py-2 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+            className="inline-flex min-h-[44px] items-center rounded-md px-3 py-3 font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
           >
             Blog
           </Link>

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -50,7 +50,7 @@ export function ThemeToggle() {
       <button
         type="button"
         aria-label="Toggle color theme"
-        className="h-9 w-9 rounded-md border border-border"
+        className="h-11 w-11 rounded-md border border-border"
         // The real handler is wired up on mount.
         disabled
       />
@@ -64,7 +64,7 @@ export function ThemeToggle() {
       onClick={() => apply(isDark ? 'light' : 'dark')}
       aria-pressed={isDark}
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-bg-elevated text-fg-muted transition-colors hover:border-accent hover:text-fg focus-visible:text-fg"
+      className="inline-flex h-11 w-11 items-center justify-center rounded-md border border-border bg-bg-elevated text-fg-muted transition-colors hover:border-accent hover:text-fg focus-visible:text-fg"
     >
       {/* Sun (shown in dark mode — click to go light) */}
       <svg


### PR DESCRIPTION
Closes #72

## Summary

Bumps the header theme toggle from 36×36 to 44×44 px, adds `min-h-[44px]` + flex-centering to the logo and nav links (`Work`, `Blog`), and wraps footer `GitHub` / `Privacy` links in `inline-flex` with `min-h-[44px]` so every persistent-chrome interactive element clears the WCAG 2.5.5 / iOS HIG 44 px tap target minimum.

Header still fits within `h-16` (64 px) with the new 44 px targets — 10 px of vertical breathing room remains. Footer inline links use `inline-flex items-center` to keep the in-sentence flow visually intact while extending the click area vertically.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [ ] Theme toggle renders at ≥ 44×44 CSS px on all viewports (`h-11 w-11`)
- [ ] Footer `GitHub` and `Privacy` links render at ≥ 44 px height (`min-h-[44px]` via `inline-flex`)
- [ ] Header nav links (`Work`, `Blog`) and `Matt Sears` logo render at ≥ 44 px height on mobile (375 px) viewport