### PR TITLE
fix(security): scope Access-Control-Allow-Origin away from wildcard on HTML

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,6 +30,30 @@ const securityHeaders = [
   },
 ];
 
+/*
+ * CORS posture — see #40.
+ *
+ * HTML routes get NO Access-Control-Allow-Origin header. Browsers don't
+ * enforce CORS on top-level HTML navigation anyway, so a wildcard ACAO on
+ * HTML is at best meaningless and at worst a smell — it lets any origin
+ * `fetch('/blog', { credentials: 'omit' })` and read the body cross-origin.
+ * The site is fully public today, so the practical exploit surface is zero,
+ * but locking it down now keeps the door closed when a future route gains
+ * auth or returns anything user-specific.
+ *
+ * The truly-public asset surface (RSS feed, sitemap, robots, llms.txt) still
+ * needs `Access-Control-Allow-Origin: *` because feed readers and AI agents
+ * fetch them cross-origin from arbitrary domains. We make that explicit here
+ * rather than relying on Vercel's per-route defaults so the behavior is
+ * stable across platform changes.
+ *
+ * Static chunks under /_next/static/* keep ACAO too — the <link rel=preload
+ * as=font crossorigin> tags Next.js emits in <head> trigger CORS-mode font
+ * fetches that fail without it.
+ */
+const publicCorsHeader = { key: 'Access-Control-Allow-Origin', value: '*' };
+const publicCorsRoutes = ['/rss.xml', '/sitemap.xml', '/robots.txt', '/llms.txt'];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['ts', 'tsx', 'js', 'jsx', 'md', 'mdx'],
@@ -44,6 +68,18 @@ const nextConfig = {
       {
         source: '/:path*',
         headers: securityHeaders,
+      },
+      // Truly-public asset routes that legitimate cross-origin clients (feed
+      // readers, AI agents, search crawlers) need to fetch directly.
+      ...publicCorsRoutes.map((source) => ({
+        source,
+        headers: [publicCorsHeader],
+      })),
+      // Static chunks — fonts preloaded with `crossorigin=""` in <head> need
+      // this for the CORS-mode fetch to succeed.
+      {
+        source: '/_next/static/:path*',
+        headers: [publicCorsHeader],
       },
     ];
   },


### PR DESCRIPTION
Closes #40

## Summary

Audit flagged every production response as serving `Access-Control-Allow-Origin: *`. Verified in production: HTML routes (`/`, `/blog`) no longer carry that header (Vercel's default appears to have shifted), but the public-asset routes (`/rss.xml`, `/sitemap.xml`, `/robots.txt`, `/llms.txt`) and `/_next/static/*` still do — and they do so via Vercel's per-route default rather than anything in this repo. That's fragile.

This PR makes the CORS posture explicit in `next.config.js`:
- HTML routes: no `Access-Control-Allow-Origin` header (browsers don't enforce CORS on top-level HTML navigation, so wildcard ACAO there is a smell, and a future route with auth/cookies would inherit it).
- `/rss.xml`, `/sitemap.xml`, `/robots.txt`, `/llms.txt`: explicit `Access-Control-Allow-Origin: *` so feed readers and AI agents can fetch cross-origin.
- `/_next/static/:path*`: explicit `Access-Control-Allow-Origin: *` so the `crossorigin=""` font preloads emitted in `<head>` continue to work.

No application code changes — purely declarative `headers()` config alongside the existing `securityHeaders` block.

## Test plan

- [x] `curl -I http://localhost:3000/` returns no `Access-Control-Allow-Origin` header
- [x] `curl -I http://localhost:3000/blog` returns no `Access-Control-Allow-Origin` header
- [x] `curl -I http://localhost:3000/rss.xml` returns `Access-Control-Allow-Origin: *`
- [x] `curl -I http://localhost:3000/sitemap.xml` returns `Access-Control-Allow-Origin: *`
- [x] `curl -I http://localhost:3000/robots.txt` returns `Access-Control-Allow-Origin: *`
- [x] `curl -I http://localhost:3000/llms.txt` returns `Access-Control-Allow-Origin: *`
- [x] `curl -I http://localhost:3000/_next/static/media/<font>.woff2` returns `Access-Control-Allow-Origin: *`
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean