### PR TITLE
chore(release): add release script + RELEASING.md for tag consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,22 @@
-.PHONY: help setup install dev build start lint typecheck format format-check verify clean
+.PHONY: help setup install dev build start lint typecheck format format-check verify clean release release-bootstrap
 
 # Default target: print available targets.
 help:
 	@echo "Available targets:"
-	@echo "  setup         Install dependencies (npm ci — clean, lockfile-driven)"
-	@echo "  install       Alias for setup"
-	@echo "  dev           Start the Next.js dev server on port 3000"
-	@echo "  build         Production build (next build)"
-	@echo "  start         Serve the production build locally"
-	@echo "  lint          ESLint via flat config"
-	@echo "  typecheck     Run tsc --noEmit"
-	@echo "  format        Prettier write across the repo"
-	@echo "  format-check  Prettier check (no writes)"
-	@echo "  verify        lint + typecheck + build (matches CI)"
-	@echo "  clean         Remove build artifacts and node_modules"
+	@echo "  setup             Install dependencies (npm ci — clean, lockfile-driven)"
+	@echo "  install           Alias for setup"
+	@echo "  dev               Start the Next.js dev server on port 3000"
+	@echo "  build             Production build (next build)"
+	@echo "  start             Serve the production build locally"
+	@echo "  lint              ESLint via flat config"
+	@echo "  typecheck         Run tsc --noEmit"
+	@echo "  format            Prettier write across the repo"
+	@echo "  format-check      Prettier check (no writes)"
+	@echo "  verify            lint + typecheck + build (matches CI)"
+	@echo "  release           Cut a release — bumps version, updates CHANGELOG, tags."
+	@echo "                    Requires KIND=patch|minor|major|X.Y.Z. See RELEASING.md."
+	@echo "  release-bootstrap First-time tag of current main HEAD at package.json's version"
+	@echo "  clean             Remove build artifacts and node_modules"
 
 setup:
 	npm ci
@@ -43,6 +46,24 @@ format-check:
 
 # Canonical "is this checkout green?" — mirrors .github/workflows/ci.yml.
 verify: lint typecheck build
+
+# Cut a release. Pass KIND=patch|minor|major|<explicit-version>:
+#   make release KIND=patch    # 0.1.0 -> 0.1.1
+#   make release KIND=minor    # 0.1.0 -> 0.2.0
+#   make release KIND=0.2.0-rc.1
+# See RELEASING.md for the full flow. The script prints push commands when done —
+# it never pushes for you.
+release:
+	@if [ -z "$(KIND)" ]; then \
+		echo "release: pass KIND=patch|minor|major|X.Y.Z (see RELEASING.md)"; \
+		exit 2; \
+	fi
+	./scripts/release.sh $(KIND)
+
+# First-time tag of current main HEAD at package.json's existing version,
+# without bumping. One-shot for issue #35 — see RELEASING.md.
+release-bootstrap:
+	./scripts/release.sh --bootstrap
 
 clean:
 	rm -rf .next out node_modules

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ A [`Makefile`](./Makefile) wraps these as one-liners for both humans and `/shipy
 ## Deployment
 
 Vercel handles deploys. Pushes to `main` trigger production; every PR gets a preview URL.
+
+## Releases
+
+Versioned by [SemVer](https://semver.org), tagged as `vX.Y.Z` against `main`. See [`RELEASING.md`](./RELEASING.md) for the full flow; the mechanics live in [`scripts/release.sh`](./scripts/release.sh) (also wrapped by `make release KIND=<patch|minor|major>`). The `CHANGELOG.md` is updated as part of the release script.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,112 @@
+# Releasing
+
+Reproducible release flow for `mattsears18.com`. The release artifact is a **git tag** of the form `vX.Y.Z` pointing at a `chore(release):` commit on `main`. Tags are the canonical "what is this commit on production?" answer — `git describe --tags` falls back to "No tags found" without them, downstream tooling (release-please, semantic-release, GitHub Releases) can't anchor anything to a version, and rollbacks become guesswork.
+
+This file is the source of truth for the convention. The mechanics live in [`scripts/release.sh`](./scripts/release.sh).
+
+## Tag scheme
+
+- **Format:** `vX.Y.Z` — leading `v`, three-part [SemVer](https://semver.org). Pre-releases use the standard form `v1.2.3-beta.1`.
+- **Source of truth for the version number:** the `version` field in [`package.json`](./package.json). The script keeps the two aligned; if they ever drift, `package.json` wins and the next release re-syncs.
+- **Annotated tags only.** `git tag -a` (not `git tag`). Annotation captures the date, author, and message — lightweight tags strip all three.
+- **Tag message:** `Release vX.Y.Z`. Plain and parse-friendly.
+
+The format aligns with the compare links already present at the bottom of [`CHANGELOG.md`](./CHANGELOG.md) (`compare/v0.1.0...HEAD`, `releases/tag/v0.1.0`). Don't change the `v` prefix without updating those.
+
+## Bootstrap — first-time setup for an existing repo
+
+This repo currently has `package.json` at `0.1.0` but no matching git tag (the gap [#35](https://github.com/mattsears18/mattsears18.com/issues/35) was filed to close). The bootstrap flow tags the current `main` HEAD with the existing version, **without** bumping or rewriting the CHANGELOG:
+
+```bash
+# From a clean main checkout, up to date with origin.
+git checkout main
+git pull --ff-only
+
+./scripts/release.sh --bootstrap   # creates annotated tag v0.1.0 locally
+```
+
+The script prints the push commands when it finishes:
+
+```bash
+git push origin v0.1.0
+# Optional — creates a GitHub Release page from the tag.
+gh release create v0.1.0 --notes-from-tag
+```
+
+After the push, `git describe --tags` will return `v0.1.0` (plus a commit-count suffix if any commits have landed since), and downstream automation has an anchor to walk back from.
+
+The bootstrap path is single-shot: the script refuses to run if a tag matching `package.json`'s version already exists locally or on origin.
+
+## Cutting a release
+
+For every subsequent release, the flow is:
+
+```bash
+# From a clean main checkout, up to date with origin.
+git checkout main
+git pull --ff-only
+
+# Choose one. patch is the most common; minor and major follow SemVer rules.
+./scripts/release.sh patch         # 0.1.0 -> 0.1.1
+./scripts/release.sh minor         # 0.1.0 -> 0.2.0
+./scripts/release.sh major         # 0.1.0 -> 1.0.0
+./scripts/release.sh 0.2.0-rc.1    # explicit, for pre-releases
+```
+
+The script:
+
+1. Verifies you're on `main` and the tree is clean.
+2. Bumps `package.json`'s `version` field.
+3. Promotes the `## [Unreleased]` block in `CHANGELOG.md` to `## [X.Y.Z] - <today>`, opens a fresh empty `## [Unreleased]` above it, and updates the compare/tag links at the bottom of the file.
+4. Creates one commit: `chore(release): vX.Y.Z`.
+5. Creates an annotated tag: `vX.Y.Z`.
+6. Prints the push commands — **the script never pushes for you**. You push manually so a misfired script (or an agent) can't publish a tag the maintainer didn't sign off on.
+
+Push when you're ready:
+
+```bash
+git push origin main
+git push origin vX.Y.Z
+gh release create vX.Y.Z --notes-from-tag   # optional — surfaces the tag on the Releases page
+```
+
+### Filling in the CHANGELOG before releasing
+
+`scripts/release.sh` only moves the `[Unreleased]` header to `[X.Y.Z]`. It does **not** rewrite the content under that header. Edit `CHANGELOG.md` directly **before** running the release script — group entries under `### Added` / `### Changed` / `### Fixed` per [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+If you forget, the easiest recovery is:
+
+```bash
+# Undo locally (does NOT undo a pushed tag).
+git tag -d vX.Y.Z
+git reset --hard HEAD~1
+
+# Edit CHANGELOG.md, then re-run.
+./scripts/release.sh <kind>
+```
+
+If the tag was already pushed, prefer a `vX.Y.(Z+1)` patch release with the missing notes rather than rewriting history.
+
+## Why not release-please / semantic-release?
+
+The audit ([#35](https://github.com/mattsears18/mattsears18.com/issues/35)) called out both as candidates. We're deferring:
+
+- **release-please** requires a GitHub App or a PAT with elevated permissions to write release PRs, and adds a `release-please-config.json` plus a `.release-please-manifest.json` to the repo root. Worth doing when the cadence justifies the per-release human time it would save — currently the manual flow is ~30 seconds and lands one commit + one tag.
+- **semantic-release** assumes Conventional Commit titles map 1:1 to release type. The repo follows that convention, but cuts versions on human judgement (a `feat(blog):` doesn't always warrant a minor bump on a personal site). Automating the version choice would invert that.
+
+Both stay open as a future improvement — file a follow-up issue if either becomes worth the integration cost.
+
+## Common pitfalls
+
+- **Forgot to push the tag.** `git push origin main` does NOT push tags by default. Push the tag explicitly: `git push origin vX.Y.Z`. (Don't use `git push --tags` — it'll push every local tag, including any experimental ones.)
+- **Pushed a tag at the wrong commit.** Delete and recreate before anyone fetches it: `git tag -d vX.Y.Z && git push origin :refs/tags/vX.Y.Z`, then re-run the script. After fetchers have it, prefer a patch release instead.
+- **CHANGELOG `[Unreleased]` is empty at release time.** Not an error per se — the version still tags. But the Releases page will be sparse. Fill it in before bumping.
+- **Working off a feature branch.** The script refuses to release off anything other than `main`. If you intentionally want to tag a non-`main` commit (rare — usually a bugfix backport), do it by hand: `git tag -a vX.Y.Z -m "Release vX.Y.Z" <sha> && git push origin vX.Y.Z`.
+
+## Acceptance criteria reference
+
+This file and `scripts/release.sh` together satisfy the acceptance criteria in [#35](https://github.com/mattsears18/mattsears18.com/issues/35):
+
+- Tagging `main` HEAD at `v0.1.0` is now a one-line command (`./scripts/release.sh --bootstrap`) — the maintainer runs it, not the agent.
+- Future releases are tagged immediately after the version bump because the bump and the tag are the **same** command.
+- `git describe --tags` will return a tag once the bootstrap tag is pushed.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# scripts/release.sh — cut a tagged release.
+#
+# What it does:
+#   1. Bumps the `version` field in package.json (semver: major | minor | patch | <explicit>).
+#   2. Promotes CHANGELOG.md's [Unreleased] block to [<new-version>] with today's date.
+#   3. Creates a commit (`chore(release): vX.Y.Z`) and an annotated tag (`vX.Y.Z`) locally.
+#   4. Prints the push commands — you push manually.
+#
+# Why manual push:
+#   Tags are load-bearing for downstream automation (release-please, CHANGELOG links,
+#   `git describe`). Forcing a human ack on the push prevents an agent or a misfired
+#   script from publishing a tag the maintainer didn't sign off on.
+#
+# Usage:
+#   ./scripts/release.sh patch          # 0.1.0 -> 0.1.1
+#   ./scripts/release.sh minor          # 0.1.0 -> 0.2.0
+#   ./scripts/release.sh major          # 0.1.0 -> 1.0.0
+#   ./scripts/release.sh 0.1.0          # explicit version (no v-prefix; the tag gets it)
+#   ./scripts/release.sh --bootstrap    # tag current HEAD with package.json's version
+#                                       # without bumping (one-shot for repos that already
+#                                       # have a version but no matching tag — see #35)
+#
+# See RELEASING.md for the full release flow.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ---------- helpers ----------
+
+die() {
+  echo "release: $*" >&2
+  exit 1
+}
+
+# Read package.json's "version" field without pulling node_modules.
+read_pkg_version() {
+  node -p "require('./package.json').version"
+}
+
+# Write a new version into package.json, preserving formatting.
+write_pkg_version() {
+  local new_version="$1"
+  node -e '
+    const fs = require("fs");
+    const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+    pkg.version = process.argv[1];
+    fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+  ' "$new_version"
+}
+
+# Bump a semver string by component. Supports: major | minor | patch | <explicit>.
+bump_semver() {
+  local current="$1"
+  local kind="$2"
+
+  if [[ "$kind" == "major" || "$kind" == "minor" || "$kind" == "patch" ]]; then
+    local major minor patch
+    IFS='.' read -r major minor patch <<< "$current"
+    case "$kind" in
+      major) echo "$((major + 1)).0.0" ;;
+      minor) echo "${major}.$((minor + 1)).0" ;;
+      patch) echo "${major}.${minor}.$((patch + 1))" ;;
+    esac
+  elif [[ "$kind" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+    echo "$kind"
+  else
+    die "invalid bump kind '$kind' — expected major|minor|patch|X.Y.Z"
+  fi
+}
+
+# Promote [Unreleased] in CHANGELOG.md to [<version>] - <today>, and add a
+# fresh [Unreleased] header above it. Also updates the bottom-of-file compare
+# links so [<version>] points at the new tag and [Unreleased] compares against
+# the new tag. Idempotent against missing CHANGELOG — no-op if absent.
+update_changelog() {
+  local new_version="$1"
+  local today
+  today="$(date -u +%Y-%m-%d)"
+
+  if [ ! -f CHANGELOG.md ]; then
+    echo "release: no CHANGELOG.md — skipping changelog update"
+    return 0
+  fi
+
+  # Pure-bash + node implementation to avoid sed portability issues across
+  # GNU / BSD sed. Read whole file, transform, write back.
+  node -e '
+    const fs = require("fs");
+    const [newVersion, today] = process.argv.slice(1);
+    let src = fs.readFileSync("CHANGELOG.md", "utf8");
+
+    // 1. Promote ## [Unreleased] header to ## [<new>] - <today>, then add a
+    //    new empty ## [Unreleased] above it.
+    const unreleasedRe = /^## \[Unreleased\]\s*$/m;
+    if (!unreleasedRe.test(src)) {
+      console.error("release: CHANGELOG.md has no [Unreleased] section — leaving untouched");
+      process.exit(0);
+    }
+    src = src.replace(
+      unreleasedRe,
+      `## [Unreleased]\n\n## [${newVersion}] - ${today}`
+    );
+
+    // 2. Update compare links at the bottom. Match either form:
+    //      [Unreleased]: https://.../compare/vOLD...HEAD
+    //    or insert if missing.
+    const repoSlug = "mattsears18/mattsears18.com";
+    const unreleasedLink = `[Unreleased]: https://github.com/${repoSlug}/compare/v${newVersion}...HEAD`;
+    const versionLink   = `[${newVersion}]: https://github.com/${repoSlug}/releases/tag/v${newVersion}`;
+
+    const unreleasedLinkRe = /^\[Unreleased\]:.*$/m;
+    if (unreleasedLinkRe.test(src)) {
+      src = src.replace(unreleasedLinkRe, unreleasedLink);
+    } else {
+      src = src.replace(/\n*$/, `\n\n${unreleasedLink}\n`);
+    }
+
+    // Insert the new version link immediately after the Unreleased link.
+    src = src.replace(unreleasedLink, `${unreleasedLink}\n${versionLink}`);
+
+    fs.writeFileSync("CHANGELOG.md", src);
+  ' "$new_version" "$today"
+}
+
+# ---------- main ----------
+
+if [ "$#" -lt 1 ]; then
+  die "missing argument — see: ./scripts/release.sh --help"
+fi
+
+case "${1:-}" in
+  -h|--help)
+    # Print only the leading header block (terminate at first blank line that
+    # is NOT inside a comment).
+    awk 'NR==1 {next} !/^#/ {exit} {sub(/^# ?/, ""); print}' "$0"
+    exit 0
+    ;;
+esac
+
+# Guard: tree must be clean. A dirty tree means uncommitted work the release
+# would silently roll into the version-bump commit.
+if [ -n "$(git status --porcelain)" ]; then
+  die "working tree is dirty — commit or stash before releasing"
+fi
+
+# Guard: must be on the default branch. Releases off a feature branch are a
+# recurring confused-tag failure mode.
+DEFAULT_BRANCH="$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-main}"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]; then
+  die "must be on '$DEFAULT_BRANCH' to release (currently on '$CURRENT_BRANCH')"
+fi
+
+# Ensure local default is up to date with remote — releasing off stale main
+# means the tag points at a commit that isn't actually the latest.
+git fetch --quiet origin "$DEFAULT_BRANCH"
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "origin/$DEFAULT_BRANCH")"
+if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+  die "local $DEFAULT_BRANCH is not aligned with origin — pull first"
+fi
+
+CURRENT_VERSION="$(read_pkg_version)"
+
+if [ "$1" = "--bootstrap" ]; then
+  # Tag the existing version without bumping. One-shot for the gap-fill case
+  # where package.json already carries a version but no matching tag exists
+  # (issue #35).
+  NEW_VERSION="$CURRENT_VERSION"
+  TAG_NAME="v${NEW_VERSION}"
+
+  if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+    die "tag $TAG_NAME already exists locally — nothing to bootstrap"
+  fi
+  if git ls-remote --exit-code --tags origin "$TAG_NAME" >/dev/null 2>&1; then
+    die "tag $TAG_NAME already exists on origin — nothing to bootstrap"
+  fi
+
+  echo "release: bootstrapping — tagging current HEAD ($LOCAL_SHA) as $TAG_NAME"
+  git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+
+  echo
+  echo "Done locally. Push the tag with:"
+  echo
+  echo "    git push origin $TAG_NAME"
+  echo
+  echo "If you also want a GitHub Release page:"
+  echo
+  echo "    gh release create $TAG_NAME --notes-from-tag"
+  echo
+  exit 0
+fi
+
+NEW_VERSION="$(bump_semver "$CURRENT_VERSION" "$1")"
+TAG_NAME="v${NEW_VERSION}"
+
+if [ "$NEW_VERSION" = "$CURRENT_VERSION" ]; then
+  die "new version ($NEW_VERSION) equals current version — refusing no-op release"
+fi
+if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
+  die "tag $TAG_NAME already exists locally"
+fi
+if git ls-remote --exit-code --tags origin "$TAG_NAME" >/dev/null 2>&1; then
+  die "tag $TAG_NAME already exists on origin"
+fi
+
+echo "release: $CURRENT_VERSION -> $NEW_VERSION (will create tag $TAG_NAME)"
+
+write_pkg_version "$NEW_VERSION"
+update_changelog "$NEW_VERSION"
+
+git add package.json
+[ -f CHANGELOG.md ] && git add CHANGELOG.md
+
+git commit -m "chore(release): $TAG_NAME"
+git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
+
+echo
+echo "Done locally. Push the commit and tag with:"
+echo
+echo "    git push origin $DEFAULT_BRANCH"
+echo "    git push origin $TAG_NAME"
+echo
+echo "If you also want a GitHub Release page:"
+echo
+echo "    gh release create $TAG_NAME --notes-from-tag"
+echo


### PR DESCRIPTION
Closes #35

## Summary

The release-readiness audit ([#35](https://github.com/mattsears18/mattsears18.com/issues/35)) flagged that `package.json` is at `0.1.0` but no git tag exists, so `git describe --tags` returns "No tags found" and downstream automation (release-please, semantic-release, `gh release`) has no anchor. This PR adds the scaffolding so tag creation is a single reproducible command going forward.

It does **not** create or push the `v0.1.0` tag itself — that ack belongs to the maintainer. Once this lands, run `make release-bootstrap` (or `./scripts/release.sh --bootstrap`) from a clean `main` checkout and push the tag.

## What changed

- **`scripts/release.sh`** — bumps `package.json`'s `version`, promotes `CHANGELOG.md`'s `[Unreleased]` block to `[X.Y.Z] - <today>`, opens a fresh `[Unreleased]` above it, updates the compare/tag links, creates a `chore(release): vX.Y.Z` commit and an annotated tag locally. Prints the push commands and exits — never pushes for you. Supports `patch` / `minor` / `major` / explicit version, plus a one-shot `--bootstrap` mode that tags current HEAD at the existing `package.json` version (the #35 backfill).
- **`RELEASING.md`** — documents the `vX.Y.Z` tag scheme, the bootstrap flow, the cut-a-release flow, why release-please / semantic-release stay deferred, and the common pitfalls.
- **`Makefile`** — adds `make release KIND=patch|minor|major|X.Y.Z` and `make release-bootstrap`, both thin wrappers around `scripts/release.sh`.
- **`README.md`** — adds a Releases section that points at `RELEASING.md`.

## Design decisions worth flagging

- **Manual push, not auto-push.** Tags are load-bearing and effectively immutable once anyone has fetched them. The script intentionally stops at "ready to push" and prints the commands the maintainer pastes themselves. That's also why this PR doesn't create the bootstrap tag — same rationale, one layer up.
- **`v`-prefixed SemVer.** Aligns with the compare links already present at the bottom of `CHANGELOG.md` (`compare/v0.1.0...HEAD`). No reason to break the existing convention.
- **No release-please / semantic-release.** Both are reasonable future moves; both require either a GitHub App or a PAT, and one of them inverts the human-judgement-on-version-bumps default the repo currently has. Deferred with a one-paragraph note in `RELEASING.md` so the next person doesn't have to re-derive the tradeoff.
- **`scripts/release.sh` is bash + `node -e` only.** No new runtime deps — the script reads/writes `package.json` and `CHANGELOG.md` via inline `node` one-liners and uses pure shell for everything else. Avoids adding a release-tooling dep that would also need versioning.

## Test plan

- [ ] `./scripts/release.sh --help` prints the leading header block cleanly (verified locally).
- [ ] `./scripts/release.sh patch` from a dirty tree refuses with `working tree is dirty` (verified locally — that's how I confirmed the guard fires on this branch).
- [ ] `make release` without `KIND=` exits 2 with the usage hint (verified locally).
- [ ] `make help` lists the two new targets (verified locally).
- [ ] CI green — only `*.md`, `Makefile`, and `scripts/release.sh` change; no JS/TS code edited.

## Follow-up

After this PR merges, the maintainer runs once:

```bash
git checkout main && git pull --ff-only
make release-bootstrap
git push origin v0.1.0
gh release create v0.1.0 --notes-from-tag   # optional
```

That closes the original acceptance criterion (`git describe --tags` returns `v0.1.0`).