### PR TITLE
fix(home): make Get in touch button work without a default mail client

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { GetInTouchButton } from '@/components/get-in-touch-button';
 import { Button } from '@/components/ui/button';
 import { defaultOpenGraph, SITE_DESCRIPTION, SITE_TITLE } from '@/lib/site';
 
@@ -43,9 +44,7 @@ export default function Home() {
         </p>
 
         <div className="mt-10 flex flex-wrap items-center gap-3">
-          <Button asChild size="lg">
-            <a href="mailto:matt@mksolutionsky.com">Get in touch</a>
-          </Button>
+          <GetInTouchButton />
           <Button asChild size="lg" variant="ghost">
             <Link href="/work">See my work</Link>
           </Button>

--- a/components/get-in-touch-button.tsx
+++ b/components/get-in-touch-button.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+
+const EMAIL = 'matt@mksolutionsky.com';
+const RESET_MS = 2400;
+
+/**
+ * Hero CTA — copies the email to clipboard with visual confirmation and
+ * also fires the mailto: navigation for users whose OS has a mail handler
+ * registered. The clipboard path is the reliable one: a plain `mailto:`
+ * silently no-ops for users without a default mail client (webmail-only
+ * users, fresh OS installs, some mobile browsers), which is what made the
+ * old hero button feel broken.
+ */
+export function GetInTouchButton() {
+  const [state, setState] = React.useState<'idle' | 'copied' | 'failed'>('idle');
+  const timeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  async function handleClick(event: React.MouseEvent<HTMLAnchorElement>) {
+    // Modifier-clicks fall through to the default mailto: handler so power
+    // users keep cmd-click / middle-click behavior.
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.button !== 0) return;
+
+    event.preventDefault();
+
+    let copied = false;
+    if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(EMAIL);
+        copied = true;
+      } catch {
+        copied = false;
+      }
+    }
+
+    setState(copied ? 'copied' : 'failed');
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setState('idle'), RESET_MS);
+
+    // Fire mailto: AFTER the clipboard write so the clipboard succeeds even
+    // when the mail handler steals focus. Using location.href instead of
+    // window.open keeps it as a same-tab navigation that the browser will
+    // either hand to a mail client or quietly drop.
+    if (typeof window !== 'undefined') {
+      window.location.href = `mailto:${EMAIL}`;
+    }
+  }
+
+  const label =
+    state === 'copied'
+      ? `Email copied — ${EMAIL}`
+      : state === 'failed'
+        ? `Email: ${EMAIL}`
+        : 'Get in touch';
+
+  return (
+    <Button asChild size="lg">
+      <a
+        href={`mailto:${EMAIL}`}
+        onClick={handleClick}
+        aria-live="polite"
+        data-state={state}
+      >
+        {label}
+      </a>
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

User-reported bug: clicking the hero **Get in touch** CTA on the landing page does nothing for anyone whose OS doesn't have a default mail handler registered (webmail-only users, fresh OS installs, some mobile browsers). The button is mechanically correct (\`<a href="mailto:matt@mksolutionsky.com">\`, \`pointer-events: auto\`, no CSP block on mailto), it's just the classic \`mailto:\`-with-no-handler silent no-op.

This PR extracts the CTA into a client component (\`components/get-in-touch-button.tsx\`) that:

- On click, **copies the email to the clipboard** and shows transient \`Email copied — matt@mksolutionsky.com\` feedback (\`data-state="copied"\`, resets after ~2.4s).
- **Still fires \`mailto:\`** after the clipboard write, so users with an OS-registered handler get their normal mail-client flow on top of the copy.
- Lets **modifier-clicks fall through** (cmd-click / ctrl-click / shift-click / middle-click) so power users keep cmd-click-to-open-in-new-tab behavior.
- Falls back to \`Email: matt@mksolutionsky.com\` (without "copied") on the rare path where \`navigator.clipboard.writeText\` throws (denied permission, insecure context), so the email is still surfaced as visible text.

The privacy page \`mailto:\` (\`app/privacy/page.tsx:146\`) is untouched — that link already renders the email as visible text right beside it, so the no-handler failure already has a working fallback there.

## Test plan

- [x] \`npm test\` (24/24 passing)
- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds
- [x] Verified via chrome-devtools on \`localhost:3000\` — button renders as \`<a href="mailto:..." data-state="idle" aria-live="polite">Get in touch</a>\`, client handler attached
- [ ] On a system **without** a mail handler: click shows "Email copied — ..." for ~2.4s, email is in clipboard
- [ ] On a system **with** a mail handler: click both copies AND opens the mail client
- [ ] Cmd-click / middle-click open the mailto: URL via the browser's default path

🤖 Generated with [Claude Code](https://claude.com/claude-code)