### PR TITLE
fix(work): break end-year ties by start-year desc

### DIFF
--- a/lib/work.test.ts
+++ b/lib/work.test.ts
@@ -33,7 +33,7 @@ afterEach(async () => {
 });
 
 describe('getAllProjects', () => {
-  it('sorts by featured first, then by end-year desc, then by title', async () => {
+  it('sorts by featured first, then by end-year desc, then by start-year desc, then by title', async () => {
     await writeProject('beta', {
       title: 'Beta',
       role: 'Eng',
@@ -68,6 +68,29 @@ describe('getAllProjects', () => {
     const projects = await getAllProjects();
 
     expect(projects.map((p) => p.slug)).toEqual(['featured', 'alpha', 'beta', 'older']);
+  });
+
+  it('breaks end-year ties by start-year desc so newer active projects lead', async () => {
+    const currentYear = new Date().getUTCFullYear();
+    await writeProject('older-active', {
+      title: 'Older Active',
+      role: 'Eng',
+      year: `${currentYear - 4}–present`,
+      summary: 's',
+      tech: ['a'],
+    });
+    await writeProject('newer-active', {
+      title: 'Newer Active',
+      role: 'Eng',
+      year: `${currentYear}–present`,
+      summary: 's',
+      tech: ['a'],
+    });
+
+    const { getAllProjects } = await import('./work');
+    const projects = await getAllProjects();
+
+    expect(projects.map((p) => p.slug)).toEqual(['newer-active', 'older-active']);
   });
 
   it('treats "present" as the current UTC year so active projects lead', async () => {

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -85,17 +85,29 @@ async function readProjectFile(filename: string): Promise<Project | null> {
 }
 
 /**
- * Year-sort key. Frontmatter `year` is human-readable ("2024–present",
+ * Year-sort keys. Frontmatter `year` is human-readable ("2024–present",
  * "2015–2018", "2019–2020") — we sort newest-first by the trailing year of
  * the range, treating "present" as the current year so active projects
- * always lead. Ties broken by title to keep the order stable.
+ * always lead. When end-years tie (common for "*-present" projects), the
+ * later start-year wins so a newer active project leads an older active
+ * one. Final tie-break is title to keep order stable.
  */
-function yearSortKey(year: string): number {
-  const parts = year.split(/[–-]/).map((p) => p.trim().toLowerCase());
-  const tail = parts[parts.length - 1];
-  if (tail === 'present') return new Date().getUTCFullYear();
-  const n = Number.parseInt(tail, 10);
+function yearPartKey(part: string | undefined): number {
+  if (!part) return 0;
+  const p = part.trim().toLowerCase();
+  if (p === 'present') return new Date().getUTCFullYear();
+  const n = Number.parseInt(p, 10);
   return Number.isFinite(n) ? n : 0;
+}
+
+function yearSortKey(year: string): number {
+  const parts = year.split(/[–-]/);
+  return yearPartKey(parts[parts.length - 1]);
+}
+
+function yearStartSortKey(year: string): number {
+  const parts = year.split(/[–-]/);
+  return yearPartKey(parts[0]);
 }
 
 export async function getAllProjects(): Promise<Project[]> {
@@ -110,12 +122,15 @@ export async function getAllProjects(): Promise<Project[]> {
   return projects
     .filter((p): p is Project => p !== null)
     .sort((a, b) => {
-      // Featured first, then most-recent end-year, then title.
+      // Featured first, then most-recent end-year, then most-recent start-year, then title.
       const featDelta =
         Number(b.frontmatter.featured ?? false) - Number(a.frontmatter.featured ?? false);
       if (featDelta !== 0) return featDelta;
       const yearDelta = yearSortKey(b.frontmatter.year) - yearSortKey(a.frontmatter.year);
       if (yearDelta !== 0) return yearDelta;
+      const startDelta =
+        yearStartSortKey(b.frontmatter.year) - yearStartSortKey(a.frontmatter.year);
+      if (startDelta !== 0) return startDelta;
       return a.frontmatter.title.localeCompare(b.frontmatter.title);
     });
 }


### PR DESCRIPTION
## Summary
- On `/work`, Shipyard (`2026–present`) and Lightwork (`2024–present`) both resolved to end-year = current UTC year, so the sort fell to title and put Lightwork first.
- Adds a start-year tie-breaker (newer start wins) before the title fallback in `lib/work.ts`, so Shipyard now leads the list while positions 3–6 remain unchanged (NCCER → VisualEyes → CDOT → Express Delphi).
- Updates `lib/work.test.ts` to document the new tie-break and cover the case explicitly.

## Test plan
- [x] `npx vitest run lib/work.test.ts` — 12 passed
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [ ] `npm run dev` and confirm `/work` order is Shipyard → Lightwork → NCCER → VisualEyes → CDOT → Express Delphi

🤖 Generated with [Claude Code](https://claude.com/claude-code)