### PR TITLE
docs(dx): record standing instruction to always auto-merge PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ CI ([`.github/workflows/ci.yml`](./.github/workflows/ci.yml)) runs `npm ci` → 
 
 ## Auto-merge
 
-Repo currently has `allow_auto_merge: false` at the repo settings level — `gh pr merge <M> --auto` will error. For trusted authors with admin perms, `gh pr merge <M> --merge --delete-branch` is the manual fallback after CI goes green. Don't try to flip the repo setting from inside a PR.
+**Always auto-merge PRs in this repo** — don't leave a PR sitting for the user to merge manually. Repo currently has `allow_auto_merge: false` at the repo settings level, so `gh pr merge <M> --auto` will error. The standing instruction therefore means: poll CI, and the moment it goes green, merge automatically without asking — `gh pr merge <M> --merge --delete-branch` is the fallback (works for trusted authors with admin perms). Don't try to flip the repo setting from inside a PR.
 
 ## What not to touch
 


### PR DESCRIPTION
Records the standing instruction to always auto-merge PRs in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)