### PR TITLE
fix(content): update NCCER SSO external link to web.myaccount.nccer.org

### DIFF
--- a/content/work/nccer-sso.mdx
+++ b/content/work/nccer-sso.mdx
@@ -5,7 +5,7 @@ year: '2019–2020'
 summary: "Architected and shipped NCCER's most-requested feature — SSO across all customer-facing services."
 tech: ['Node.js', 'OAuth 2.0', 'OpenID Connect', 'AWS']
 links:
-  external: 'https://myaccount.nccer.org'
+  external: 'https://web.myaccount.nccer.org'
 featured: true
 image: '/work/nccer-sso.jpg'
 imageAlt: 'NCCER Single Sign-On — login screen'


### PR DESCRIPTION
Closes #130.

Updates the NCCER Single Sign-On work entry's external link from `https://myaccount.nccer.org` to `https://web.myaccount.nccer.org` in `content/work/nccer-sso.mdx` frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)