### PR TITLE
fix(content): update VisualEyes paper link to Google Scholar citation

### DIFF
--- a/content/work/visual-eyes.mdx
+++ b/content/work/visual-eyes.mdx
@@ -7,7 +7,7 @@ tech: ['React', 'Meteor', 'MongoDB', 'Vercel', 'Plotly', 'jStat']
 links:
   youtube: 'https://www.youtube.com/watch?v=Ed6oByh5tJw'
   github: 'https://github.com/mattsears18/visual-eyes'
-  paper: 'https://www.researchgate.net/publication/343178511_Advanced_Eye_Tracking_Analysis_for_Investigating_Construction_Craft_Professional_Interactions_with_2D_Drawings'
+  paper: 'https://scholar.google.com/citations?view_op=view_citation&hl=en&user=XglzLYcAAAAJ&citation_for_view=XglzLYcAAAAJ:2osOgNQ5qMEC'
 featured: true
 image: '/work/visual-eyes.jpg'
 imageAlt: 'VisualEyes — eye-tracking analysis app screenshot'


### PR DESCRIPTION
Closes #131.

Updates the VisualEyes work entry's `paper` link from the ResearchGate publication URL to the Google Scholar citation in `content/work/visual-eyes.mdx` frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)