### PR TITLE
fix(work): show full hero image on project detail pages

### DIFF
--- a/app/components/project-image.tsx
+++ b/app/components/project-image.tsx
@@ -45,7 +45,7 @@ export function ProjectImage({ project, variant, className }: Props) {
           fill
           sizes={SIZES_BY_VARIANT[variant]}
           priority={variant === 'hero'}
-          className="object-cover"
+          className={variant === 'hero' ? 'object-contain' : 'object-cover'}
         />
       </div>
     );


### PR DESCRIPTION
Closes #129

## Summary
The project detail hero rendered inside a fixed `aspect-[16/9]` wrapper with `object-cover`, which crops any image whose aspect ratio isn't 16:9. The Shipyard marketing graphic is ~3:2 (1168×784), so its title band and bottom caption fell outside the frame and were never visible. This switches the `hero` variant to `object-contain` so the full image fits inside the stable wrapper, letterboxed against the existing `bg-bg-elevated` background. The `card` variant keeps `object-cover` for uniform grid tiles (Option A from the issue).

## Test plan
- [ ] `/work/shipyard` shows the full graphic (title + bottom caption visible), letterboxed rather than cropped
- [ ] `/work` grid cards remain uniformly cropped tiles (card variant unchanged)
- [x] `npm run lint`, `npx tsc --noEmit`, and `npm run build` pass locally