### PR TITLE
fix(seo,web): trim home meta description under the 160-char snippet limit

### DIFF
--- a/lib/site.ts
+++ b/lib/site.ts
@@ -6,7 +6,7 @@
 export const SITE_URL = 'https://mattsears18.com';
 export const SITE_TITLE = 'Matt Sears';
 export const SITE_DESCRIPTION =
-  'Matt Sears — software engineer with a civil engineering PhD. Lead engineer at SalesRiver, board member at Enrich, and builder of Shipyard and Lightwork on the side.';
+  'Matt Sears — software engineer with a civil engineering PhD. Lead at SalesRiver, board member at Enrich, building Shipyard and Lightwork on the side.';
 export const SITE_TAGLINE = 'Software engineer with a civil engineering PhD.';
 
 /**


### PR DESCRIPTION
## What

Trims the home page `SITE_DESCRIPTION` from 164 to 149 chars so the `<meta name="description">` no longer exceeds the ~160-char limit at which Google truncates SERP snippets mid-sentence.

Before (164):
> Matt Sears — software engineer with a civil engineering PhD. Lead engineer at SalesRiver, board member at Enrich, and builder of Shipyard and Lightwork on the side.

After (149):
> Matt Sears — software engineer with a civil engineering PhD. Lead at SalesRiver, board member at Enrich, building Shipyard and Lightwork on the side.

Every entity is preserved (PhD, SalesRiver, Enrich, Shipyard, Lightwork, "on the side"); only "Lead engineer"→"Lead" and "and builder of"→"building" were trimmed. No meaning lost.

## Scope

- Single change to `SITE_DESCRIPTION` in `lib/site.ts`. The constant also feeds `og:description` / `twitter:description` (no hard limit), so share cards are unaffected. No other routes touched — each has its own description string.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean
- `npm run build` succeeds

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)