### PR TITLE
fix(security,deps): pin postcss 8.5.15 via overrides to clear GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10099,34 +10099,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,9 @@
     "tailwindcss": "3.4.3",
     "typescript": "5.4.5"
   },
+  "overrides": {
+    "postcss": "8.5.15"
+  },
   "devDependencies": {
     "@vercel/toolbar": "^0.2.6",
     "@vitest/coverage-v8": "^4.1.7",


### PR DESCRIPTION
Closes #162

## Summary

Next bundled `postcss@8.4.31` — vulnerable to GHSA-qx2v-qp2m-jg93 (CSS-stringify XSS) — at `node_modules/next/node_modules/postcss`, the root cause behind all 6 moderate `npm audit` findings. A `package.json` `overrides` entry pins `postcss` to `8.5.15` (the version the project already declares top-level), which dedupes the nested copy away entirely. `npm audit` now reports **0 vulnerabilities** and the production build still passes — Next's build pipeline runs fine on the patched postcss.

The lockfile change is a pure removal: the `8.4.31` nested entry is gone (28 deletions, 0 additions to dependency resolution), since every postcss in the tree now resolves to the single `8.5.15` copy.

## Test plan

- [x] `npm audit` reports `found 0 vulnerabilities`
- [x] `npm ls postcss` shows every postcss (incl. under `next`) resolving to `8.5.15`; nested `next/node_modules/postcss` no longer exists
- [x] `npm run build` succeeds
- [x] `npm run lint`, `npx tsc --noEmit`, `npm test` (25 tests) all pass