### PR TITLE
feat(dx): add /health liveness endpoint

### DIFF
--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,0 +1,27 @@
+/*
+ * `/health` — liveness endpoint for uptime monitors, load balancers, and
+ * container orchestration probes (Better Uptime, UptimeRobot, k8s, etc.).
+ *
+ * Returns `200 {"status":"ok"}` with no auth. The site is a static
+ * portfolio with no database or external runtime dependency, so there is
+ * nothing to ping here — the route's job is purely "is the server process
+ * answering requests". A `timestamp` is included so a monitor can detect a
+ * stale/cached response.
+ *
+ * Forced dynamic + `no-store` on purpose: a cached static health response
+ * would keep reporting 200 from the CDN edge even if the origin were down,
+ * which defeats the point of a liveness probe. See #169.
+ */
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return Response.json(
+    { status: 'ok', timestamp: new Date().toISOString() },
+    {
+      status: 200,
+      headers: {
+        'Cache-Control': 'no-store, max-age=0',
+      },
+    },
+  );
+}


### PR DESCRIPTION
Closes #169

## Summary

Adds a `GET /health` App Router route handler (`app/health/route.ts`) returning `200` with a JSON liveness payload (`{"status":"ok","timestamp":"<ISO>"}`) and no auth, so uptime monitors, load balancers, and container orchestration probes have a cheap "is the app up" target instead of falling back to root.

The route is forced dynamic (`export const dynamic = 'force-dynamic'`) and sends `Cache-Control: no-store` — a CDN-cached static health response would keep reporting `200` from the edge even if the origin were down, defeating the point of a liveness probe. The optional dependency-ping acceptance criterion is N/A: this is a static portfolio site with no database or external runtime dependency to verify.

## Test plan

- [x] `npm run build` succeeds; `/health` compiles as a dynamic (`ƒ`) route.
- [x] `npx tsc --noEmit` and `npm run lint` clean.
- [x] Served the production build and curled `/health`: returns `200`, `content-type: application/json`, body `{"status":"ok","timestamp":...}`, `cache-control: no-store, max-age=0`.
- [x] Endpoint requires no auth (no auth gate; reachable anonymously).