### PR TITLE
feat(seo,web): add CreativeWork JSON-LD to work project pages

### DIFF
--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 
 import { JsonLd } from '@/app/components/json-ld';
 import { ProjectImage } from '@/app/components/project-image';
-import { breadcrumbListSchema } from '@/lib/json-ld';
+import { breadcrumbListSchema, creativeWorkSchema } from '@/lib/json-ld';
 import { formatLinkLabel, getAllProjects, getProjectBySlug } from '@/lib/work';
 import { defaultOpenGraph, SITE_TITLE } from '@/lib/site';
 
@@ -64,11 +64,21 @@ export default async function ProjectPage({ params }: { params: Promise<Params> 
   return (
     <article className="mx-auto max-w-reading py-12 sm:py-16">
       <JsonLd
-        schema={breadcrumbListSchema([
-          { name: 'Home', path: '/' },
-          { name: 'Work', path: '/work' },
-          { name: project.frontmatter.title, path: `/work/${slug}` },
-        ])}
+        schema={[
+          breadcrumbListSchema([
+            { name: 'Home', path: '/' },
+            { name: 'Work', path: '/work' },
+            { name: project.frontmatter.title, path: `/work/${slug}` },
+          ]),
+          creativeWorkSchema({
+            title: project.frontmatter.title,
+            summary: project.frontmatter.summary,
+            slug,
+            tech: project.frontmatter.tech,
+            year: project.frontmatter.year,
+            links: Object.values(links),
+          }),
+        ]}
       />
       <nav className="mb-10">
         <Link

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -75,3 +75,46 @@ export function breadcrumbListSchema(items: BreadcrumbItem[]) {
     })),
   } as const;
 }
+
+/**
+ * CreativeWork schema — one per `/work/<slug>` project detail page.
+ *
+ * Describes the project itself as a discrete structured entity authored by
+ * Matt, so Google's Knowledge Graph treats each portfolio item as a creator's
+ * work rather than an opaque webpage. Every field is sourced from the project's
+ * MDX frontmatter (title/summary/tech/year) or the route slug — no
+ * request-derived input, matching the safety contract in `<JsonLd>`.
+ *
+ * `keywords` is the comma-joined tech stack (schema.org's documented shape for
+ * a keyword list on CreativeWork). `dateCreated` carries the project's
+ * end-year so the entity is temporally anchored; `url` is absolutized against
+ * `SITE_URL` for the same reason BreadcrumbList items are. When the project
+ * frontmatter exposes outbound links (live site / repo / paper), they're
+ * surfaced as `sameAs` to help disambiguate the entity — omitted entirely when
+ * there are none rather than emitting an empty array.
+ */
+export type CreativeWorkInput = {
+  title: string;
+  summary: string;
+  slug: string;
+  tech: string[];
+  year: string;
+  /** Outbound project URLs (live site, repo, paper, …) — used as `sameAs`. */
+  links?: string[];
+};
+
+export function creativeWorkSchema(project: CreativeWorkInput) {
+  const sameAs = (project.links ?? []).filter((url) => url.startsWith('http'));
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'CreativeWork',
+    name: project.title,
+    description: project.summary,
+    url: `${SITE_URL}/work/${project.slug}`,
+    keywords: project.tech.join(', '),
+    dateCreated: project.year,
+    author: { '@type': 'Person', name: SITE_TITLE, url: SITE_URL },
+    inLanguage: 'en-US',
+    ...(sameAs.length > 0 ? { sameAs } : {}),
+  } as const;
+}


### PR DESCRIPTION
Closes #167

## Summary

Work project detail pages (`/work/[slug]`) previously emitted only `Person`, `WebSite`, and `BreadcrumbList` JSON-LD — none of which described the project itself as a structured entity. This adds a `creativeWorkSchema` generator to `lib/json-ld.ts` and emits it on every work page alongside the preserved `BreadcrumbList`, so Google's Knowledge Graph treats each portfolio item as a discrete `CreativeWork` authored by Matt rather than an opaque webpage.

Every field is sourced from the project's existing MDX frontmatter (`title`, `summary`, `tech`, `year`) or the route slug — no request-derived input, matching the safety contract in `<JsonLd>`. When a project's frontmatter exposes outbound links (live site / repo / paper), they're surfaced as `sameAs` to help disambiguate the entity; omitted entirely when there are none.

## Test plan

- [x] Every `/work/[slug]` page emits a `CreativeWork` block with `name`, `description`, `url`, and `author` (verified across all 6 slugs via the prod server: shipyard, lightwork, nccer-sso, visual-eyes, cdot-duration-predictor, express-delphi).
- [x] Existing `BreadcrumbList` block is preserved alongside the new block (confirmed: each page emits `[Person, WebSite, BreadcrumbList, CreativeWork]`).
- [x] `lib/json-ld.ts` exports `creativeWorkSchema` with a `CreativeWorkInput` type.
- [x] `npm run lint`, `npx tsc --noEmit`, and `npm run build` pass locally.
- [ ] Schema validates in Google's Rich Results Test without errors (manual post-merge check).