### PR TITLE
fix(observability): wire App Router error boundaries to Sentry.captureException

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import * as Sentry from '@sentry/nextjs';
+
+/*
+ * Route-segment error boundary — `app/error.tsx`.
+ *
+ * In the App Router, an uncaught exception thrown while *rendering a Client
+ * Component* (or re-thrown into render from a client event handler) is caught
+ * by the nearest `error.tsx` boundary. `instrumentation.ts`'s `onRequestError`
+ * only sees *server-side* errors — it never sees client render crashes — so
+ * without this boundary forwarding to Sentry those errors render a fallback UI
+ * and produce ZERO operator signal (no event, no alert, no stack trace).
+ * See #158 (and the deferred criterion on the now-closed #43).
+ *
+ * This file renders INSIDE the root layout's `<main>` (the root layout itself
+ * survived; only a child segment crashed), so it inherits the site header,
+ * footer, fonts, theme tokens, and container width — same chrome as
+ * `app/not-found.tsx`. Layout-level crashes that escape the root layout fall
+ * through to `app/global-error.tsx` instead.
+ *
+ * `reset()` re-renders the segment that threw — a cheap retry for transient
+ * failures (a flaky fetch, a hydration race) without a full page reload.
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <section
+      aria-labelledby="error-heading"
+      className="flex min-h-[60vh] flex-col justify-center py-16 sm:py-24"
+    >
+      <p className="mb-6 font-mono text-sm uppercase tracking-widest text-fg-muted">Error</p>
+
+      <h1
+        id="error-heading"
+        className="max-w-3xl font-display text-display-sm font-medium tracking-tight text-fg sm:text-display-md"
+      >
+        Something broke<span className="text-accent">.</span>
+      </h1>
+
+      <p className="mt-8 max-w-2xl text-lg leading-relaxed text-fg-muted sm:text-xl">
+        An unexpected error stopped this page from rendering. It&apos;s been reported automatically.
+        Try again, or head back home.
+      </p>
+
+      <p className="mt-10 flex flex-wrap gap-x-6 gap-y-2 text-base sm:text-lg">
+        <button
+          type="button"
+          onClick={reset}
+          className="text-accent underline-offset-4 hover:underline"
+        >
+          Try again →
+        </button>
+        <Link href="/" className="text-accent underline-offset-4 hover:underline">
+          Home →
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+import './globals.css';
+
+/*
+ * Root error boundary — `app/global-error.tsx`.
+ *
+ * This is the last-resort boundary: it catches errors thrown in the *root
+ * layout itself* (or anything that escapes a segment `error.tsx`). Because the
+ * root layout has crashed, this component REPLACES it entirely — so it must
+ * render its own `<html>` and `<body>` (the surrounding `app/layout.tsx`
+ * chrome — header, footer, font variables, theme class — is gone).
+ *
+ * Like `app/error.tsx`, this forwards the caught error to Sentry on mount so a
+ * root-render crash produces an operator signal instead of a silent broken
+ * page. See #158.
+ *
+ * Branding caveat: with the root layout gone we don't get the `next/font`
+ * CSS variables or the `.dark` class the layout normally stamps on `<html>`.
+ * We import `globals.css` for the design tokens and apply `dark` directly so
+ * the recovery UI stays on-theme (dark default, accent headline) rather than
+ * falling back to an unstyled Next default. The `font-display` alias resolves
+ * to its system-font fallback here (the Geist variable isn't injected without
+ * the layout) — acceptable for a rarely-hit last-resort surface.
+ */
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en" className="dark" style={{ colorScheme: 'dark' }}>
+      <body className="min-h-screen bg-bg font-sans text-fg antialiased">
+        <main className="mx-auto max-w-container px-6 sm:px-12">
+          <section
+            aria-labelledby="global-error-heading"
+            className="flex min-h-screen flex-col justify-center py-16 sm:py-24"
+          >
+            <p className="mb-6 font-mono text-sm uppercase tracking-widest text-fg-muted">Error</p>
+
+            <h1
+              id="global-error-heading"
+              className="max-w-3xl font-display text-display-sm font-medium tracking-tight text-fg sm:text-display-md"
+            >
+              Something broke<span className="text-accent">.</span>
+            </h1>
+
+            <p className="mt-8 max-w-2xl text-lg leading-relaxed text-fg-muted sm:text-xl">
+              An unexpected error stopped this page from rendering. It&apos;s been reported
+              automatically. Reload the page, or head back home.
+            </p>
+
+            <p className="mt-10 flex flex-wrap gap-x-6 gap-y-2 text-base sm:text-lg">
+              {/*
+               * Plain <a> (full navigation), not next/link: the root layout
+               * crashed, so the App Router's client context this boundary
+               * renders under is unreliable. A hard navigation re-bootstraps
+               * the app from scratch. This is also what the @sentry/nextjs +
+               * Next.js global-error examples use.
+               */}
+              {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+              <a href="/" className="text-accent underline-offset-4 hover:underline">
+                Home →
+              </a>
+            </p>
+          </section>
+        </main>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Closes #158

## Summary

Client-side React render crashes were escaping Sentry entirely. `instrumentation.ts`'s `onRequestError` only covers server-side errors, and there was no `app/error.tsx` / `app/global-error.tsx` to forward client render crashes — so a crash in any Client Component on the golden path produced a broken page with zero operator signal (no event, no alert, no stack trace).

This adds both App Router error boundaries, each a Client Component forwarding the caught error to `Sentry.captureException` on mount:

- **`app/error.tsx`** — catches segment-level client render crashes. Renders inside the root layout's `<main>` (inherits header/footer/fonts/theme), offers a `reset()` retry and a Home link, matching the styling of `app/not-found.tsx`.
- **`app/global-error.tsx`** — last-resort boundary for crashes that escape the root layout. Replaces the layout, so it renders its own `<html>`/`<body>`, imports `globals.css` for the design tokens, and applies the `dark` default so the recovery UI stays branded. Uses a plain `<a>` (full navigation) since the router context is unreliable after a root-layout crash — consistent with the `@sentry/nextjs` + Next.js global-error examples.

This satisfies the one acceptance criterion left unchecked when the Sentry-wiring issue #43 was closed.

Did not touch `app/layout.tsx` — a sibling issue owns the head.

## Test plan

- [x] `app/error.tsx` exists, is a Client Component, calls `Sentry.captureException(error)` in a `useEffect` keyed on `error`.
- [x] `app/global-error.tsx` exists, is a Client Component, calls `Sentry.captureException(error)`, wraps its own `<html><body>`.
- [x] Both render a branded recovery UI consistent with `app/not-found.tsx` (accent headline, mono eyebrow, theme tokens) — no unstyled Next default.
- [x] `npm run lint` clean.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run build` succeeds (both boundaries compile into the route tree).