### PR TITLE
feat(release,web): add manifest.webmanifest for PWA installability

### DIFF
--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,0 +1,48 @@
+import type { MetadataRoute } from 'next';
+
+import { SITE_DESCRIPTION, SITE_TITLE } from '@/lib/site';
+
+/*
+ * `/manifest.webmanifest` — emitted by Next from this file at build time.
+ *
+ * The App Router `manifest` file convention auto-injects
+ * `<link rel="manifest" href="/manifest.webmanifest">` into every route's
+ * <head>, which is what makes the site installable as a PWA (add-to-home-
+ * screen on Android, web-app-install banners). No static asset in `public/`
+ * — the manifest is generated, same pattern as `robots.ts` / `sitemap.ts`.
+ *
+ * Colors come from the design tokens in `app/globals.css`:
+ *   - background_color `#0a0a0a` = `--color-bg` (dark, the SSR default theme)
+ *   - theme_color      `#f97316` = the orange brand accent (matches the
+ *     accent period in `app/apple-icon.tsx` / `app/opengraph-image.tsx`)
+ *
+ * Icons reference `/icon-192.png` + `/icon-512.png`. Those PNG assets are
+ * owned by #144 (replace favicon.ico with modern PWA icons) — this manifest
+ * names the standard paths #144 produces so the two land independently
+ * without colliding. Referencing OG/Twitter images here is owned by #142.
+ */
+export const dynamic = 'force-static';
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: SITE_TITLE,
+    short_name: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    start_url: '/',
+    display: 'standalone',
+    background_color: '#0a0a0a',
+    theme_color: '#f97316',
+    icons: [
+      {
+        src: '/icon-192.png',
+        sizes: '192x192',
+        type: 'image/png',
+      },
+      {
+        src: '/icon-512.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
+    ],
+  };
+}


### PR DESCRIPTION
Closes #141

## Summary

Adds an `app/manifest.ts` metadata route so Next.js emits `/manifest.webmanifest` at build time and auto-injects `<link rel="manifest" href="/manifest.webmanifest">` into every route's `<head>` — the prerequisite for PWA installability (add-to-home-screen on Android, web-app-install banners). Follows the same generated-route pattern as `app/robots.ts` and `app/sitemap.ts`; no static asset committed.

Manifest fields: `name`/`short_name`/`description` from `lib/site.ts`, `start_url: "/"`, `display: "standalone"`, `background_color: "#0a0a0a"` (the dark `--color-bg` token) and `theme_color: "#f97316"` (the orange brand accent). The icons array references `/icon-192.png` and `/icon-512.png` (192×192 + 512×512, `type: image/png`) — those PNG assets are owned by #144, so this PR names the standard paths without creating the bytes. Referencing OG/Twitter images in the manifest is owned by #142. `app/apple-icon.tsx` is left untouched per scope.

## Test plan

- [x] `app/manifest.webmanifest` route exists and emits valid JSON per the Web App Manifest spec (verified generated body)
- [x] Manifest includes `name`, `short_name`, `start_url`, `display`, `theme_color`, `background_color`
- [x] Icons array includes 192×192 and 512×512 entries with `type: "image/png"` and `sizes` fields
- [x] `<link rel="manifest" href="/manifest.webmanifest">` present on `/`, `/blog`, and `/work` (verified against `npm start`)
- [x] `/manifest.webmanifest` served with `content-type: application/manifest+json`
- [x] `npx tsc --noEmit`, `eslint`, and `npm run build` all pass

Note: the Lighthouse-installable PWA score and the on-device install prompt depend on the 192/512 icon bytes landing via #144; this PR delivers the manifest + link-tag half of the installability requirement.