### PR TITLE
fix(observability,content): report malformed MDX to Sentry instead of dropping it silently

### DIFF
--- a/lib/posts.test.ts
+++ b/lib/posts.test.ts
@@ -2,10 +2,22 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { captureException } from '@sentry/nextjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `@sentry/nextjs` has no DSN in the test runtime, so `captureException` is a
+// no-op at runtime — but we mock it here so we can assert the content readers
+// report parse/read failures (issue #153). The namespace export can't be spied
+// directly under ESM, so mock the module; `vi.mock` is hoisted above the import.
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+const captureMock = vi.mocked(captureException);
 
 let tmpDir: string;
 const realCwd = process.cwd.bind(process);
+
+async function writeRawPost(slug: string, raw: string) {
+  await fs.writeFile(path.join(tmpDir, 'content', 'posts', `${slug}.mdx`), raw, 'utf8');
+}
 
 async function writePost(slug: string, frontmatter: Record<string, unknown>, body = 'Body.') {
   const yaml = Object.entries(frontmatter)
@@ -22,6 +34,7 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'posts-test-'));
   await fs.mkdir(path.join(tmpDir, 'content', 'posts'), { recursive: true });
   vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  captureMock.mockClear();
   vi.resetModules();
 });
 
@@ -73,12 +86,38 @@ describe('getAllPosts', () => {
     expect(posts).toEqual([]);
   });
 
-  it('throws with the slug in the error when required frontmatter is missing', async () => {
-    await writePost('incomplete', { title: 'Only title' });
+  it('skips a malformed file instead of collapsing the whole listing, and reports it to Sentry', async () => {
+    const capture = captureMock;
+    await writePost('good-one', { title: 'Good One', date: '2025-03-01', excerpt: 'e' });
+    await writePost('incomplete', { title: 'Only title' }); // missing date + excerpt
+    await writePost('good-two', { title: 'Good Two', date: '2025-01-01', excerpt: 'e' });
 
     const { getAllPosts } = await import('./posts');
+    const posts = await getAllPosts();
 
-    await expect(getAllPosts()).rejects.toThrow(/incomplete/);
+    // The one bad file is dropped; the good ones survive (no zeroing).
+    expect(posts.map((p) => p.slug)).toEqual(['good-one', 'good-two']);
+    // The failure is reported with the slug so an operator gets a breadcrumb.
+    expect(capture).toHaveBeenCalledTimes(1);
+    const [err, ctx] = capture.mock.calls[0];
+    expect((err as Error).message).toMatch(/incomplete/);
+    expect(ctx).toMatchObject({ tags: { op: 'readPost', slug: 'incomplete' } });
+  });
+
+  it('skips a file with broken YAML frontmatter and reports it rather than throwing out', async () => {
+    const capture = captureMock;
+    await writePost('good', { title: 'Good', date: '2025-01-01', excerpt: 'e' });
+    // Unterminated/invalid YAML so gray-matter throws inside matter().
+    await writeRawPost('broken-yaml', '---\ntitle: "unterminated\ndate: 2025-01-01\n---\nBody.\n');
+
+    const { getAllPosts } = await import('./posts');
+    const posts = await getAllPosts();
+
+    expect(posts.map((p) => p.slug)).toEqual(['good']);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][1]).toMatchObject({
+      tags: { op: 'readPost', slug: 'broken-yaml' },
+    });
   });
 });
 
@@ -107,6 +146,28 @@ describe('getPostBySlug', () => {
     const post = await getPostBySlug('wip');
 
     expect(post).toBeNull();
+  });
+
+  it('reports a malformed post to Sentry and returns null instead of throwing', async () => {
+    const capture = captureMock;
+    await writePost('broken', { title: 'Only title' }); // missing date + excerpt
+
+    const { getPostBySlug } = await import('./posts');
+    const post = await getPostBySlug('broken');
+
+    expect(post).toBeNull();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][1]).toMatchObject({ tags: { op: 'readPost', slug: 'broken' } });
+  });
+
+  it('does not report to Sentry for a simple not-found (ENOENT) miss', async () => {
+    const capture = captureMock;
+
+    const { getPostBySlug } = await import('./posts');
+    const post = await getPostBySlug('never-existed');
+
+    expect(post).toBeNull();
+    expect(capture).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import * as Sentry from '@sentry/nextjs';
 import matter from 'gray-matter';
 
 export type PostFrontmatter = {
@@ -39,7 +40,21 @@ export async function getAllPosts(): Promise<Post[]> {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw err;
   }
-  const posts = await Promise.all(entries.map(readPostFile));
+  // Per-file isolation: a single malformed file (bad YAML, missing required
+  // frontmatter) is reported to Sentry and skipped rather than throwing out of
+  // the map and collapsing the entire blog index / sitemap / RSS / llms.txt to
+  // empty. See #153.
+  const posts = await Promise.all(
+    entries.map(async (filename) => {
+      try {
+        return await readPostFile(filename);
+      } catch (err) {
+        const slug = filename.replace(/\.mdx$/, '');
+        Sentry.captureException(err, { tags: { op: 'readPost', slug } });
+        return null;
+      }
+    }),
+  );
   return posts
     .filter((p): p is Post => p !== null)
     .filter((p) => !p.frontmatter.draft)
@@ -53,7 +68,11 @@ export async function getPostBySlug(slug: string): Promise<Post | null> {
     return post;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
+    // Report the parse/read failure before returning the fallback so a
+    // malformed post that 404s leaves an operator breadcrumb instead of
+    // vanishing silently. See #153.
+    Sentry.captureException(err, { tags: { op: 'readPost', slug } });
+    return null;
   }
 }
 

--- a/lib/work.test.ts
+++ b/lib/work.test.ts
@@ -2,10 +2,22 @@ import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
+import { captureException } from '@sentry/nextjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `@sentry/nextjs` has no DSN in the test runtime, so `captureException` is a
+// no-op at runtime — but we mock it here so we can assert the content readers
+// report parse/read failures (issue #153). The namespace export can't be spied
+// directly under ESM, so mock the module; `vi.mock` is hoisted above the import.
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }));
+const captureMock = vi.mocked(captureException);
 
 let tmpDir: string;
 const realCwd = process.cwd.bind(process);
+
+async function writeRawProject(slug: string, raw: string) {
+  await fs.writeFile(path.join(tmpDir, 'content', 'work', `${slug}.mdx`), raw, 'utf8');
+}
 
 async function writeProject(slug: string, frontmatter: Record<string, unknown>, body = 'Body.') {
   const yaml = Object.entries(frontmatter)
@@ -23,6 +35,7 @@ beforeEach(async () => {
   await fs.mkdir(path.join(tmpDir, 'content', 'work'), { recursive: true });
   await fs.mkdir(path.join(tmpDir, 'public', 'work'), { recursive: true });
   vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+  captureMock.mockClear();
   vi.resetModules();
 });
 
@@ -197,15 +210,37 @@ describe('getAllProjects', () => {
     expect(project.frontmatter.imageAlt).toBe('kept');
   });
 
-  it('throws with the slug in the error when required frontmatter is missing', async () => {
+  it('skips a project with missing required frontmatter and reports it to Sentry', async () => {
+    const capture = captureMock;
+    await writeProject('good', {
+      title: 'Good',
+      role: 'Eng',
+      year: '2020',
+      summary: 's',
+      tech: ['a'],
+    });
     await writeProject('incomplete', { title: 'Only title' });
 
     const { getAllProjects } = await import('./work');
+    const projects = await getAllProjects();
 
-    await expect(getAllProjects()).rejects.toThrow(/incomplete/);
+    // The bad file is dropped; the good one survives (no zeroing of the listing).
+    expect(projects.map((p) => p.slug)).toEqual(['good']);
+    expect(capture).toHaveBeenCalledTimes(1);
+    const [err, ctx] = capture.mock.calls[0];
+    expect((err as Error).message).toMatch(/incomplete/);
+    expect(ctx).toMatchObject({ tags: { op: 'readProject', slug: 'incomplete' } });
   });
 
-  it('throws when tech is an empty array', async () => {
+  it('skips a project with an empty tech array and reports it rather than throwing out', async () => {
+    const capture = captureMock;
+    await writeProject('good', {
+      title: 'Good',
+      role: 'Eng',
+      year: '2020',
+      summary: 's',
+      tech: ['a'],
+    });
     await writeProject('no-tech', {
       title: 'No Tech',
       role: 'Eng',
@@ -215,8 +250,34 @@ describe('getAllProjects', () => {
     });
 
     const { getAllProjects } = await import('./work');
+    const projects = await getAllProjects();
 
-    await expect(getAllProjects()).rejects.toThrow(/no-tech/);
+    expect(projects.map((p) => p.slug)).toEqual(['good']);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][1]).toMatchObject({
+      tags: { op: 'readProject', slug: 'no-tech' },
+    });
+  });
+
+  it('skips a project with broken YAML frontmatter and reports it', async () => {
+    const capture = captureMock;
+    await writeProject('good', {
+      title: 'Good',
+      role: 'Eng',
+      year: '2020',
+      summary: 's',
+      tech: ['a'],
+    });
+    await writeRawProject('broken-yaml', '---\ntitle: "unterminated\nrole: Eng\n---\nBody.\n');
+
+    const { getAllProjects } = await import('./work');
+    const projects = await getAllProjects();
+
+    expect(projects.map((p) => p.slug)).toEqual(['good']);
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][1]).toMatchObject({
+      tags: { op: 'readProject', slug: 'broken-yaml' },
+    });
   });
 
   it('returns an empty array when the work directory does not exist', async () => {
@@ -226,6 +287,47 @@ describe('getAllProjects', () => {
     const projects = await getAllProjects();
 
     expect(projects).toEqual([]);
+  });
+});
+
+describe('getProjectBySlug', () => {
+  it('returns the project when the slug matches a valid file', async () => {
+    await writeProject('hello', {
+      title: 'Hello',
+      role: 'Eng',
+      year: '2020',
+      summary: 's',
+      tech: ['a'],
+    });
+
+    const { getProjectBySlug } = await import('./work');
+    const project = await getProjectBySlug('hello');
+
+    expect(project?.frontmatter.title).toBe('Hello');
+  });
+
+  it('reports a malformed project to Sentry and returns null instead of throwing', async () => {
+    const capture = captureMock;
+    await writeProject('broken', { title: 'Only title' });
+
+    const { getProjectBySlug } = await import('./work');
+    const project = await getProjectBySlug('broken');
+
+    expect(project).toBeNull();
+    expect(capture).toHaveBeenCalledTimes(1);
+    expect(capture.mock.calls[0][1]).toMatchObject({
+      tags: { op: 'readProject', slug: 'broken' },
+    });
+  });
+
+  it('does not report to Sentry for a simple not-found (ENOENT) miss', async () => {
+    const capture = captureMock;
+
+    const { getProjectBySlug } = await import('./work');
+    const project = await getProjectBySlug('never-existed');
+
+    expect(project).toBeNull();
+    expect(capture).not.toHaveBeenCalled();
   });
 });
 

--- a/lib/work.ts
+++ b/lib/work.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 
+import * as Sentry from '@sentry/nextjs';
 import matter from 'gray-matter';
 
 /**
@@ -118,7 +119,21 @@ export async function getAllProjects(): Promise<Project[]> {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw err;
   }
-  const projects = await Promise.all(entries.map(readProjectFile));
+  // Per-file isolation: a single malformed project file (bad YAML, missing
+  // required frontmatter) is reported to Sentry and skipped rather than
+  // throwing out of the map and zeroing the entire work listing / sitemap /
+  // llms.txt. See #153.
+  const projects = await Promise.all(
+    entries.map(async (filename) => {
+      try {
+        return await readProjectFile(filename);
+      } catch (err) {
+        const slug = filename.replace(/\.mdx$/, '');
+        Sentry.captureException(err, { tags: { op: 'readProject', slug } });
+        return null;
+      }
+    }),
+  );
   return projects
     .filter((p): p is Project => p !== null)
     .sort((a, b) => {
@@ -140,7 +155,11 @@ export async function getProjectBySlug(slug: string): Promise<Project | null> {
     return await readProjectFile(`${slug}.mdx`);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
+    // Report the parse/read failure before returning the fallback so a
+    // malformed project that 404s leaves an operator breadcrumb instead of
+    // vanishing silently. See #153.
+    Sentry.captureException(err, { tags: { op: 'readProject', slug } });
+    return null;
   }
 }
 


### PR DESCRIPTION
Closes #153

## Summary

The content readers (`lib/posts.ts`, `lib/work.ts`) swallowed parse/read errors and converted them to a fallback (`null` / `[]`) with no operator signal. Worse, `getAllPosts` / `getAllProjects` mapped the per-file reader over every entry inside a single `Promise.all`, so **one** malformed `.mdx` threw out of the map and collapsed the *entire* blog index / work listing / sitemap / RSS / `llms.txt` to empty.

This PR reports before swallowing and isolates per-file failures so one bad file can't zero the listing.

## Changes

- **Per-file isolation** — moved the `try/catch` *inside* the `.map()` in `getAllPosts` / `getAllProjects`. A single malformed file (bad YAML, missing required frontmatter, empty `tech[]`) is now reported to Sentry (`Sentry.captureException(err, { tags: { op, slug } })`) and skipped, instead of throwing out and emptying the array.
- **Single-item readers** — `getPostBySlug` / `getProjectBySlug` now report non-ENOENT failures to Sentry before returning `null`, so a malformed single post/project that 404s leaves a breadcrumb instead of vanishing.
- The intentional directory-missing ENOENT fallback (`getAllPosts` / `getAllProjects` `readdir` catch) is preserved as-is.

`@sentry/nextjs` is already a dependency and initialized via `instrumentation.ts`; `captureException` is a safe no-op when no DSN is set (local/CI/dev).

## Test plan

- [x] A malformed `content/posts/*.mdx` (missing frontmatter or broken YAML) is reported to Sentry with the slug tag instead of silently disappearing — covered by new `posts.test.ts` cases.
- [x] One malformed file removes only that entry from the listing — the good files survive (no zeroing). Verified the test fails against the old `Promise.all(entries.map(reader))` behavior.
- [x] Same per-file isolation + reporting applied to `lib/work.ts` (`work.test.ts` cases for missing frontmatter, empty `tech[]`, broken YAML).
- [x] The intentional directory-missing fallback is preserved (existing "returns empty array when directory does not exist" tests still pass).
- [x] `npm test` (32 pass), `tsc --noEmit`, and `eslint .` all clean locally.

> Note: the production `next build` could not be run inside the agent worktree because Turbopack rejects the worktree's `node_modules` symlink ("points out of the filesystem root"); the change is pure TypeScript in `lib/` and is fully covered by `tsc` + the vitest suite. CI runs `npm ci` into a real `node_modules` and builds normally.