### PR TITLE
docs(dx): correct README lint description to flat-config eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## Scripts
 
-| Command         | What it does                          |
-| --------------- | ------------------------------------- |
-| `npm run dev`   | Start the dev server on port 3000     |
-| `npm run build` | Production build (run before pushing) |
-| `npm start`     | Serve the production build locally    |
-| `npm run lint`  | ESLint via `next lint`                |
+| Command         | What it does                                 |
+| --------------- | -------------------------------------------- |
+| `npm run dev`   | Start the dev server on port 3000            |
+| `npm run build` | Production build (run before pushing)        |
+| `npm start`     | Serve the production build locally           |
+| `npm run lint`  | ESLint via flat config (`eslint.config.mjs`) |
 
 A [`Makefile`](./Makefile) wraps these as one-liners for both humans and `/shipyard:do-work` agents:
 


### PR DESCRIPTION
Closes #180

## Summary

The README Scripts table described `npm run lint` as "ESLint via `next lint`", but `package.json` runs `eslint .` (flat config via `eslint.config.mjs`). `next lint` was removed in Next.js 16 and the script was already migrated in #80 — only the README table's description text carried the stale wording. Corrected the cell to match reality (and the wording already used in `CLAUDE.md`), re-aligning the table column.

## Test plan
- [ ] README Scripts table row for `npm run lint` now reads "ESLint via flat config (`eslint.config.mjs`)", matching `package.json`'s `"lint": "eslint ."`.