### PR TITLE
chore(privacy,compliance): surface Sentry DPA link and cross-border transfer mechanism

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -127,8 +127,18 @@ export default function PrivacyPage() {
             className="text-accent underline-offset-4 hover:underline"
           >
             Sentry&apos;s privacy policy
+          </a>{' '}
+          and{' '}
+          <a
+            href="https://sentry.io/legal/dpa/"
+            target="_blank"
+            rel="noreferrer"
+            className="text-accent underline-offset-4 hover:underline"
+          >
+            data processing addendum
           </a>
-          .
+          . Error events are processed on Sentry&apos;s US infrastructure; the EU&rarr;US transfer
+          relies on EU Standard Contractual Clauses (SCCs) per Sentry&apos;s DPA.
         </p>
 
         <h2>External links</h2>


### PR DESCRIPTION
Closes #150

## Summary

The `/privacy` page disclosed Sentry as a data processor but linked only to its privacy policy — missing the DPA link and any mention of the cross-border transfer mechanism (the Vercel section already discloses both). This adds the [Sentry DPA](https://sentry.io/legal/dpa/) link and a one-sentence note that the EU→US error-event transfer relies on EU Standard Contractual Clauses (SCCs), mirroring the existing Vercel disclosure pattern.

`PRIVACY_DATA_PROCESSORS.md` (line 14) already records the Sentry DPA + SCCs transfer mechanism, so the internal inventory and the visitor-facing page are now in sync without a change to the inventory.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] Prettier-clean
- [ ] Sentry section in `/privacy` links to Sentry's DPA (https://sentry.io/legal/dpa/)
- [ ] Sentry section mentions the transfer mechanism (SCCs) for EU→US error-event transfers
- [ ] Disclosure pattern is consistent between the Vercel and Sentry sections
- [ ] `PRIVACY_DATA_PROCESSORS.md` and `/privacy` remain in sync