### PR TITLE
fix(a11y,web): raise work page secondary link tap targets to 44px

### DIFF
--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -143,7 +143,7 @@ export default async function WorkIndexPage() {
                             href={href}
                             target="_blank"
                             rel="noreferrer"
-                            className="text-accent underline-offset-4 hover:underline"
+                            className="inline-flex min-h-[44px] items-center text-accent underline-offset-4 hover:underline"
                           >
                             {formatLinkLabel(key)} ↗
                           </a>


### PR DESCRIPTION
Closes #173

## Summary

The secondary action links (GitHub ↗, Visit ↗, YouTube ↗, etc.) on each `/work` project card rendered at line-height (~16px tall) — well below the WCAG 2.5.5 / 2.5.8 44px tap-target recommendation. This adds `inline-flex min-h-[44px] items-center` to each link, the same pattern already used by the footer and nav links (`app/components/site-footer.tsx`, `app/components/site-header.tsx`), so the hit area reaches 44px without changing the visible label's appearance.

Scope confined to `app/work/page.tsx` per the dispatch scope hint. The detail-page header links (`app/work/[slug]/page.tsx`, acceptance criterion #2) are a separate surface and out of scope for this PR.

## Test plan

- [ ] Each secondary link on `/work` now has a ≥44px hit area (`min-h-[44px]`), satisfying the WCAG 2.5.8 minimum and the 44px preferred recommendation.
- [ ] Visible style unchanged — `inline-flex items-center` centers the existing font-mono / text-xs / uppercase / text-accent label vertically; the extra height is padding above/below the text.
- [ ] `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass locally.