### PR TITLE
fix(a11y,web): scope blog post card link name to the post title

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -60,8 +60,15 @@ export default async function BlogIndexPage() {
           {posts.map((post) => (
             <li key={post.slug} className="py-8 sm:py-10">
               <article>
-                <Link href={`/blog/${post.slug}`} className="group block">
-                  <h2 className="font-display text-2xl font-medium tracking-tight text-fg group-hover:text-accent sm:text-3xl">
+                <Link
+                  href={`/blog/${post.slug}`}
+                  aria-labelledby={`post-title-${post.slug}`}
+                  className="group block"
+                >
+                  <h2
+                    id={`post-title-${post.slug}`}
+                    className="font-display text-2xl font-medium tracking-tight text-fg group-hover:text-accent sm:text-3xl"
+                  >
                     {post.frontmatter.title}
                   </h2>
                   <p className="mt-2 font-mono text-xs uppercase tracking-widest text-fg-muted">


### PR DESCRIPTION
Closes #177

## Summary

Each blog post card on `/blog` was rendered as a single `<Link>` wrapping the title, date, and excerpt with no `aria-label`, so screen readers computed the link's accessible name by concatenating all inner text into a verbose run-on string ("Hello from the new site May 24, 2026 A short note on what this site is for…"). This adds `aria-labelledby` on the `<Link>` pointing at the post's `<h2>` (given a per-post `id`), so the accessible name is just the title — while the heading still contributes to the page outline and the date/excerpt stay visually rendered. `aria-labelledby` was chosen over the issue's suggested `aria-hidden`-on-the-heading approach because hiding the `<h2>` from the accessibility tree would drop it from the heading outline, violating acceptance criterion 3.

## Test plan

- [x] Screen readers announce the card link as just the post title — verified via the Playwright accessibility snapshot: `link "Hello from the new site"` (was the full run-on string).
- [x] Date and excerpt remain visually rendered on the card (still present in the a11y tree as `time` + excerpt paragraph).
- [x] The `<h2>` still contributes to the heading outline — snapshot shows `heading "Hello from the new site" [level=2]`.
- [x] `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass.