### PR TITLE
feat(seo,web): add Article JSON-LD schema to blog post pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { JsonLd } from '@/app/components/json-ld';
-import { breadcrumbListSchema } from '@/lib/json-ld';
+import { articleSchema, breadcrumbListSchema } from '@/lib/json-ld';
 import { formatPostDate, getAllPosts, getPostBySlug } from '@/lib/posts';
 import { defaultOpenGraph, SITE_TITLE } from '@/lib/site';
 
@@ -52,11 +52,19 @@ export default async function PostPage({ params }: { params: Promise<Params> }) 
   return (
     <article className="mx-auto max-w-reading py-12 sm:py-16">
       <JsonLd
-        schema={breadcrumbListSchema([
-          { name: 'Home', path: '/' },
-          { name: 'Blog', path: '/blog' },
-          { name: post.frontmatter.title, path: `/blog/${slug}` },
-        ])}
+        schema={[
+          breadcrumbListSchema([
+            { name: 'Home', path: '/' },
+            { name: 'Blog', path: '/blog' },
+            { name: post.frontmatter.title, path: `/blog/${slug}` },
+          ]),
+          articleSchema({
+            title: post.frontmatter.title,
+            excerpt: post.frontmatter.excerpt,
+            date: post.frontmatter.date,
+            slug,
+          }),
+        ]}
       />
       <nav className="mb-10">
         <Link

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -118,3 +118,44 @@ export function creativeWorkSchema(project: CreativeWorkInput) {
     ...(sameAs.length > 0 ? { sameAs } : {}),
   } as const;
 }
+
+/**
+ * Article schema — one per `/blog/<slug>` post detail page.
+ *
+ * Qualifies blog posts for Google's Article rich result (headline +
+ * datePublished + author), so SERP entries can render as enhanced cards
+ * rather than plain blue links. Every field is sourced from the post's MDX
+ * frontmatter (title/date/excerpt) or the route slug — no request-derived
+ * input, matching the safety contract documented in `<JsonLd>`.
+ *
+ * `headline` carries the post title; `datePublished` is the frontmatter
+ * `date` (kept verbatim — it's already an ISO-ish date string Google
+ * accepts). `url` is absolutized against `SITE_URL` for the same reason
+ * BreadcrumbList items and CreativeWork URLs are. Both `author` and
+ * `publisher` resolve to Matt as a single-author personal site (mirroring
+ * `creativeWorkSchema`'s `author` shape). No `image` field is emitted —
+ * post frontmatter has no image source (`PostFrontmatter` exposes only
+ * title/date/excerpt/tags/draft), and fabricating one would mislead the
+ * Rich Results validator; `image` is recommended, not required, for the
+ * Article rich result.
+ */
+export type ArticleInput = {
+  title: string;
+  excerpt: string;
+  date: string;
+  slug: string;
+};
+
+export function articleSchema(post: ArticleInput) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    headline: post.title,
+    description: post.excerpt,
+    datePublished: post.date,
+    url: `${SITE_URL}/blog/${post.slug}`,
+    author: { '@type': 'Person', name: SITE_TITLE, url: SITE_URL },
+    publisher: { '@type': 'Person', name: SITE_TITLE, url: SITE_URL },
+    inLanguage: 'en-US',
+  } as const;
+}


### PR DESCRIPTION
Closes #164

## Summary

Blog post pages (`/blog/[slug]`) emitted only `Person`, `WebSite`, and `BreadcrumbList` JSON-LD — none of which qualify for Google's Article rich result. This adds an `articleSchema` builder to `lib/json-ld.ts` (mirroring the existing `creativeWorkSchema`/`breadcrumbListSchema` patterns) and wires it into `app/blog/[slug]/page.tsx`'s `<JsonLd>` array alongside the preserved `BreadcrumbList` block.

The `Article` block sources `headline`/`description`/`datePublished` from the post's MDX frontmatter (`title`/`excerpt`/`date`) and the route slug for `url` — no request-derived input, matching the safety contract in `<JsonLd>`. `author` and `publisher` both resolve to Matt (single-author personal site). No `image` field is emitted: `PostFrontmatter` has no image source, and fabricating one would mislead the validator; `image` is recommended, not required, for the Article rich result.

## Test plan

- [x] `npx tsc --noEmit` passes (criterion: `articleSchema` typed via `as const` + typed `ArticleInput`, no `any`)
- [x] `npm run lint` passes on both changed files
- [x] `npm run build` succeeds
- [x] Served the production build and confirmed `/blog/hello-from-the-new-site` now emits an `Article` JSON-LD block with `headline`, `datePublished`, `author`, and `url`, with the existing `BreadcrumbList` block preserved alongside it