### PR TITLE
fix(seo,web): render RSS autodiscovery <link> in <head> on every route

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,6 +120,22 @@ export default async function RootLayout({ children }: { children: React.ReactNo
          * components against their depth in the URL hierarchy.
          */}
         <JsonLd schema={[personSchema(), websiteSchema()]} />
+        {/*
+         * RSS autodiscovery — see #159. Emitted as a raw <link> here rather
+         * than via metadata `alternates.types` because Next.js App Router does
+         * NOT deep-merge `alternates` across the layout/page boundary: a
+         * page-level `alternates: { canonical }` (present on the blog/work
+         * detail routes) replaces the root layout's `alternates` entirely,
+         * dropping `types`. This mirrors the JsonLd raw-<head> pattern and the
+         * og:site_name merge-drop fix in #68, so the feed link renders on
+         * every route regardless of page-level metadata overrides.
+         */}
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title={`${SITE_TITLE} — RSS`}
+          href="/rss.xml"
+        />
       </head>
       <body className="min-h-screen bg-bg text-fg">
         {/*


### PR DESCRIPTION
Closes #159

## Summary

The RSS feed at `/rss.xml` had no autodiscovery `<link rel="alternate" type="application/rss+xml">` in `<head>` on any route, so feed readers (Feedly, NetNewsWire) and crawlers couldn't find it. The root layout declared `alternates.types` for RSS, but that metadata-level declaration did not render — and the page-level `alternates: { canonical }` overrides on the blog/work detail routes replaced the layout's `alternates` entirely (the same merge-drop pattern as #68). This adds the feed link as a raw `<link>` in the root layout `<head>`, mirroring the existing `<JsonLd>` raw-head pattern, so it renders route-agnostically.

## Test plan

- [x] `curl` of `/` returns `<link rel="alternate" type="application/rss+xml" title="Matt Sears — RSS" href="/rss.xml"/>`.
- [x] Autodiscovery link present on `/`, `/blog`, `/blog/hello-from-the-new-site`, `/work`, `/work/shipyard` (verified against a local `next start` build — including the two routes that override `alternates`).
- [x] `/rss.xml` still resolves to valid RSS 2.0 (HTTP 200, `application/xml`).
- [x] `npm run lint`, `npx tsc --noEmit`, and `npm run build` all pass.