### PR TITLE
test(api): cover the 4 public route handlers (rss.xml, llms.txt, sitemap.xml, robots.txt)

### DIFF
--- a/app/llms.txt/route.test.ts
+++ b/app/llms.txt/route.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Post } from '@/lib/posts';
+import type { Project } from '@/lib/work';
+
+vi.mock('@/lib/posts', () => ({ getAllPosts: vi.fn() }));
+vi.mock('@/lib/work', () => ({ getAllProjects: vi.fn() }));
+
+import { getAllPosts } from '@/lib/posts';
+import { getAllProjects } from '@/lib/work';
+
+import { GET } from './route';
+
+const getAllPostsMock = vi.mocked(getAllPosts);
+const getAllProjectsMock = vi.mocked(getAllProjects);
+
+function makePost(slug: string): Post {
+  return {
+    slug,
+    frontmatter: {
+      title: `Post ${slug}`,
+      date: '2024-03-15',
+      excerpt: `Excerpt ${slug}.`,
+    },
+    content: 'Body.',
+  };
+}
+
+function makeProject(slug: string): Project {
+  return {
+    slug,
+    frontmatter: {
+      title: `Project ${slug}`,
+      role: 'Eng',
+      year: '2024',
+      summary: `Summary ${slug}.`,
+      tech: ['ts'],
+    },
+    content: 'Body.',
+  };
+}
+
+beforeEach(() => {
+  getAllPostsMock.mockReset();
+  getAllProjectsMock.mockReset();
+});
+
+describe('GET /llms.txt', () => {
+  it('serves text/plain with the documented cache-control header', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const res = await GET();
+
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=3600');
+  });
+
+  it('emits the llmstxt.org header (# title + > tagline)', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('# Matt Sears');
+    expect(body).toContain('> Software engineer with a civil engineering PhD.');
+  });
+
+  it('builds absolute URLs from relative hrefs via bullet()', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    // Static portfolio links are relative hrefs that bullet() should absolutize.
+    expect(body).toContain('[Home](https://mattsears18.com/)');
+    expect(body).toContain('[Work](https://mattsears18.com/work)');
+    expect(body).toContain('[Blog](https://mattsears18.com/blog)');
+  });
+
+  it('leaves already-absolute hrefs untouched (no double prefix)', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).not.toContain('https://mattsears18.comhttps://');
+  });
+
+  it('caps the Projects section at PROJECTS_LIMIT (6) entries', async () => {
+    getAllProjectsMock.mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => makeProject(`p${i}`)),
+    );
+    getAllPostsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('/work/p0');
+    expect(body).toContain('/work/p5');
+    expect(body).not.toContain('/work/p6');
+  });
+
+  it('caps the Recent posts section at POSTS_LIMIT (10) entries', async () => {
+    getAllPostsMock.mockResolvedValue(Array.from({ length: 15 }, (_, i) => makePost(`b${i}`)));
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('/blog/b0');
+    expect(body).toContain('/blog/b9');
+    expect(body).not.toContain('/blog/b10');
+  });
+
+  it('renders Projects and Recent posts sections when their lists are non-empty', async () => {
+    getAllProjectsMock.mockResolvedValue([makeProject('only')]);
+    getAllPostsMock.mockResolvedValue([makePost('only')]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('## Projects');
+    expect(body).toContain('## Recent posts');
+    expect(body).toContain('[Project only](https://mattsears18.com/work/only): Summary only.');
+    expect(body).toContain('[Post only](https://mattsears18.com/blog/only): Excerpt only.');
+  });
+
+  it('omits the Projects section when there are no projects', async () => {
+    getAllProjectsMock.mockResolvedValue([]);
+    getAllPostsMock.mockResolvedValue([makePost('only')]);
+
+    const body = await (await GET()).text();
+
+    expect(body).not.toContain('## Projects');
+    expect(body).toContain('## Recent posts');
+  });
+
+  it('omits the Recent posts section when there are no posts', async () => {
+    getAllProjectsMock.mockResolvedValue([makeProject('only')]);
+    getAllPostsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('## Projects');
+    expect(body).not.toContain('## Recent posts');
+  });
+
+  it('always emits the Feeds section pointing at the sibling endpoints', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('## Feeds');
+    expect(body).toContain('[RSS feed](https://mattsears18.com/rss.xml)');
+    expect(body).toContain('[Sitemap](https://mattsears18.com/sitemap.xml)');
+  });
+});

--- a/app/robots.txt/route.test.ts
+++ b/app/robots.txt/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { GET } from './route';
+
+describe('GET /robots.txt', () => {
+  it('serves text/plain with the documented cache-control header', () => {
+    const res = GET();
+
+    expect(res.headers.get('Content-Type')).toBe('text/plain; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=3600');
+  });
+
+  it('emits an allow-all policy', async () => {
+    const body = await GET().text();
+
+    expect(body).toContain('User-Agent: *');
+    expect(body).toContain('Allow: /');
+    expect(body).not.toContain('Disallow:');
+  });
+
+  it('points Host and Sitemap at SITE_URL', async () => {
+    const body = await GET().text();
+
+    expect(body).toContain('Host: https://mattsears18.com');
+    expect(body).toContain('Sitemap: https://mattsears18.com/sitemap.xml');
+  });
+
+  it('terminates the body with a trailing newline', async () => {
+    const body = await GET().text();
+
+    expect(body.endsWith('\n')).toBe(true);
+  });
+});

--- a/app/rss.xml/route.test.ts
+++ b/app/rss.xml/route.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Post } from '@/lib/posts';
+
+// Mock the data reader so the handler's serialization logic is exercised in
+// isolation, mirroring the `lib/*.test.ts` pattern. `vi.mock` is hoisted above
+// the import of the route module.
+vi.mock('@/lib/posts', () => ({ getAllPosts: vi.fn() }));
+
+import { getAllPosts } from '@/lib/posts';
+
+import { GET } from './route';
+
+const getAllPostsMock = vi.mocked(getAllPosts);
+
+function makePost(slug: string, overrides: Partial<Post['frontmatter']> = {}): Post {
+  return {
+    slug,
+    frontmatter: {
+      title: `Title ${slug}`,
+      date: '2024-03-15',
+      excerpt: `Excerpt for ${slug}.`,
+      ...overrides,
+    },
+    content: 'Body.',
+  };
+}
+
+beforeEach(() => {
+  getAllPostsMock.mockReset();
+});
+
+describe('GET /rss.xml', () => {
+  it('serves RSS XML with the documented content-type and cache-control headers', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('hello')]);
+
+    const res = await GET();
+
+    expect(res.headers.get('Content-Type')).toBe('application/xml; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=3600');
+  });
+
+  it('emits a well-formed RSS 2.0 feed envelope', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('hello')]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('<?xml version="1.0" encoding="utf-8"?>');
+    expect(body).toContain('<rss version="2.0"');
+    expect(body).toContain('<title>Matt Sears</title>');
+  });
+
+  it('maps each post to an item with the absolute /blog/<slug> link, title, and description', async () => {
+    getAllPostsMock.mockResolvedValue([
+      makePost('first', { title: 'First Post', excerpt: 'First excerpt.' }),
+      makePost('second', { title: 'Second Post', excerpt: 'Second excerpt.' }),
+    ]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('https://mattsears18.com/blog/first');
+    expect(body).toContain('First Post');
+    expect(body).toContain('First excerpt.');
+    expect(body).toContain('https://mattsears18.com/blog/second');
+    expect(body).toContain('Second Post');
+  });
+
+  it('emits one <item> per post returned by the reader', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('a'), makePost('b'), makePost('c')]);
+
+    const body = await (await GET()).text();
+
+    expect((body.match(/<item>/g) ?? []).length).toBe(3);
+  });
+
+  it('parses the frontmatter date as UTC midnight (no off-by-one timezone drift)', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('dated', { date: '2024-03-15' })]);
+
+    const body = await (await GET()).text();
+
+    // `feed` renders pubDate in RFC-822; a `${date}T00:00:00Z` parse pins it to
+    // 15 Mar 2024 00:00:00 GMT regardless of the host timezone.
+    expect(body).toContain('15 Mar 2024 00:00:00 GMT');
+  });
+
+  it('emits a feed with no items when there are no posts', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('<rss version="2.0"');
+    expect((body.match(/<item>/g) ?? []).length).toBe(0);
+  });
+});

--- a/app/sitemap.xml/route.test.ts
+++ b/app/sitemap.xml/route.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Post } from '@/lib/posts';
+import type { Project } from '@/lib/work';
+
+vi.mock('@/lib/posts', () => ({ getAllPosts: vi.fn() }));
+vi.mock('@/lib/work', () => ({ getAllProjects: vi.fn() }));
+
+import { getAllPosts } from '@/lib/posts';
+import { getAllProjects } from '@/lib/work';
+
+import { GET } from './route';
+
+const getAllPostsMock = vi.mocked(getAllPosts);
+const getAllProjectsMock = vi.mocked(getAllProjects);
+
+function makePost(slug: string): Post {
+  return {
+    slug,
+    frontmatter: {
+      title: `Post ${slug}`,
+      date: '2024-03-15',
+      excerpt: `Excerpt ${slug}.`,
+    },
+    content: 'Body.',
+  };
+}
+
+function makeProject(slug: string): Project {
+  return {
+    slug,
+    frontmatter: {
+      title: `Project ${slug}`,
+      role: 'Eng',
+      year: '2024',
+      summary: `Summary ${slug}.`,
+      tech: ['ts'],
+    },
+    content: 'Body.',
+  };
+}
+
+/** Pull every <loc> URL out of the sitemap XML body. */
+function extractLocs(body: string): string[] {
+  const locs: string[] = [];
+  const re = /<loc>([^<]+)<\/loc>/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    locs.push(match[1]);
+  }
+  return locs;
+}
+
+beforeEach(() => {
+  getAllPostsMock.mockReset();
+  getAllProjectsMock.mockReset();
+});
+
+describe('GET /sitemap.xml', () => {
+  it('serves sitemap XML with the documented content-type and cache-control headers', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const res = await GET();
+
+    expect(res.headers.get('Content-Type')).toBe('application/xml; charset=utf-8');
+    expect(res.headers.get('Cache-Control')).toBe('public, max-age=3600, s-maxage=3600');
+  });
+
+  it('emits a well-formed urlset envelope', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(body).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+    expect(body.trimEnd()).toMatch(/<\/urlset>$/);
+  });
+
+  it('includes the four static routes', async () => {
+    getAllPostsMock.mockResolvedValue([]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const locs = extractLocs(await (await GET()).text());
+
+    expect(locs).toContain('https://mattsears18.com');
+    expect(locs).toContain('https://mattsears18.com/blog');
+    expect(locs).toContain('https://mattsears18.com/work');
+    expect(locs).toContain('https://mattsears18.com/privacy');
+  });
+
+  it('emits one entry per post and per project', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('p1'), makePost('p2')]);
+    getAllProjectsMock.mockResolvedValue([makeProject('w1')]);
+
+    const locs = extractLocs(await (await GET()).text());
+
+    expect(locs).toContain('https://mattsears18.com/blog/p1');
+    expect(locs).toContain('https://mattsears18.com/blog/p2');
+    expect(locs).toContain('https://mattsears18.com/work/w1');
+    // 4 static + 2 posts + 1 project
+    expect(locs.length).toBe(7);
+  });
+
+  it('emits lastmod, changefreq, and priority for every entry', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('p1')]);
+    getAllProjectsMock.mockResolvedValue([makeProject('w1')]);
+
+    const body = await (await GET()).text();
+
+    // One <url> block per entry; each carries all four child tags.
+    const urlBlocks = (body.match(/<url>/g) ?? []).length;
+    expect(urlBlocks).toBe(6);
+    expect((body.match(/<lastmod>/g) ?? []).length).toBe(6);
+    expect((body.match(/<changefreq>/g) ?? []).length).toBe(6);
+    expect((body.match(/<priority>/g) ?? []).length).toBe(6);
+    // priority is rendered with a single decimal place.
+    expect(body).toContain('<priority>1.0</priority>');
+  });
+
+  it('uses the frontmatter date (UTC midnight) for post lastmod', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('dated')]);
+    getAllProjectsMock.mockResolvedValue([]);
+
+    const body = await (await GET()).text();
+
+    expect(body).toContain('<lastmod>2024-03-15T00:00:00.000Z</lastmod>');
+  });
+
+  it('emits no trailing slash on any URL (regression guard for #70)', async () => {
+    getAllPostsMock.mockResolvedValue([makePost('p1')]);
+    getAllProjectsMock.mockResolvedValue([makeProject('w1')]);
+
+    const locs = extractLocs(await (await GET()).text());
+
+    expect(locs.length).toBeGreaterThan(0);
+    for (const loc of locs) {
+      expect(loc.endsWith('/')).toBe(false);
+    }
+    // The canonical root is the bare origin, not `https://.../`.
+    expect(locs).toContain('https://mattsears18.com');
+    expect(locs).not.toContain('https://mattsears18.com/');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,27 @@
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  // Mirror the `@/*` -> `./` path alias from `tsconfig.json` so route handlers
+  // and the modules they import (`@/lib/site`, `@/lib/posts`, `@/lib/work`)
+  // resolve under Vitest. Without this, `app/**` specs that import a route
+  // handler fail at module resolution. See #155.
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
   test: {
     environment: 'node',
-    include: ['lib/**/*.test.ts', 'lib/**/*.test.tsx'],
+    // `lib/**` covers the data-reader specs; `app/**` covers the public
+    // route-handler specs (`rss.xml`, `llms.txt`, `sitemap.xml`, `robots.txt`).
+    include: ['lib/**/*.test.ts', 'lib/**/*.test.tsx', 'app/**/*.test.ts', 'app/**/*.test.tsx'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],
-      include: ['lib/**/*.{ts,js}'],
-      exclude: ['lib/**/*.test.{ts,tsx}'],
+      include: ['lib/**/*.{ts,js}', 'app/**/route.{ts,js}'],
+      exclude: ['lib/**/*.test.{ts,tsx}', 'app/**/*.test.{ts,tsx}'],
     },
   },
 });


### PR DESCRIPTION
Closes #155

## Summary

Adds one Vitest spec per build-time public route handler — `app/rss.xml/route.ts`, `app/llms.txt/route.ts`, `app/sitemap.xml/route.ts`, `app/robots.txt/route.ts` — each mocking `getAllPosts` / `getAllProjects` (mirroring the `lib/*.test.ts` pattern), invoking the exported `GET()`, and asserting on the emitted body **and** the `Content-Type` / `Cache-Control` response headers. No route handler is modified.

To make the co-located `app/**` specs actually run, `vitest.config.ts` now (1) resolves the `@/*` path alias from `tsconfig.json` (the handlers import `@/lib/site`, `@/lib/posts`, `@/lib/work`, which Vitest did not resolve before) and (2) widens the test `include` to `app/**/*.test.ts`. These are config-only changes; the four handlers are untouched.

## Test plan

- [x] `git grep -l 'rss.xml|llms.txt|sitemap|robots' -- '*.test.ts'` returns a spec for each of the four handlers
- [x] Each spec asserts on emitted body content (not just non-throwing); `rss.xml` + `llms.txt` specs assert `Content-Type` and `Cache-Control`
- [x] `sitemap` spec asserts URLs carry no trailing slash (regression guard for #70)
- [x] `npm test` passes with the new specs (59 tests, 7 files)
- [x] `npm run lint` and `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)