### PR TITLE
docs(dx): add Quickstart section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,19 @@ Personal site for Matt Sears. Next.js 16 (App Router) + React 19 + Tailwind + MD
 
 See [`docs/architecture.md`](./docs/architecture.md) for the locked tech stack and content model, and [`docs/design.md`](./docs/design.md) for typography, palette, and layout tokens.
 
+## Quickstart
+
+**Prerequisites:** Node `>=22.0.0` (the [`.nvmrc`](./.nvmrc) pins `24.15.0` — run `nvm use` to match) and **npm** ([`package-lock.json`](./package-lock.json) is the source of truth).
+
+```bash
+git clone https://github.com/mattsears18/mattsears18.com.git
+cd mattsears18.com
+npm install
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000).
+
 ## Local development
 
 ```bash


### PR DESCRIPTION
Closes #160

## Summary
Adds a `## Quickstart` section near the top of `README.md` covering the clone → install → `npm run dev` path, plus the prerequisites (Node `>=22.0.0` from `package.json` engines, `.nvmrc` pin `24.15.0`, npm as the package manager). This satisfies the dx-audit onboarding probe that scans for a conventional Install/Quickstart/Getting Started heading, which the existing `## Local development` section did not provide. The change is additive — `## Local development` and all other sections are untouched.

## Test plan
- [ ] `README.md` contains a `## Quickstart` heading (matches the audit probe regex `^#+ +(install|quickstart|getting started|setup|usage)`).
- [ ] Heading lists the exact commands with no placeholders (clone, `cd`, `npm install`, `npm run dev`).
- [ ] Prerequisites reflect `.nvmrc` (`24.15.0`) and `package.json` engines (`>=22.0.0`).