### PR TITLE
fix(a11y,web): label breadcrumb nav on detail pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -66,7 +66,7 @@ export default async function PostPage({ params }: { params: Promise<Params> }) 
           }),
         ]}
       />
-      <nav className="mb-10">
+      <nav aria-label="Breadcrumb" className="mb-10">
         <Link
           href="/blog"
           className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -80,7 +80,7 @@ export default async function ProjectPage({ params }: { params: Promise<Params> 
           }),
         ]}
       />
-      <nav className="mb-10">
+      <nav aria-label="Breadcrumb" className="mb-10">
         <Link
           href="/work"
           className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"


### PR DESCRIPTION
Closes #172

## Summary

The breadcrumb `<nav>` on the work and blog detail pages had no `aria-label`, so screen-reader users navigating by landmark saw two unlabelled "navigation" regions and couldn't distinguish the breadcrumb from the site-wide primary nav. This adds `aria-label="Breadcrumb"` to the breadcrumb `<nav>` in both `app/work/[slug]/page.tsx` and `app/blog/[slug]/page.tsx`. The primary nav already carries `aria-label="Primary"` (in `app/components/site-header.tsx`), so the two landmarks are now distinguishable. WCAG 2.1 SC 1.3.1 / SC 4.1.2.

## Test plan

- [ ] `/work/[slug]` breadcrumb `<nav>` has `aria-label="Breadcrumb"`.
- [ ] `/blog/[slug]` breadcrumb `<nav>` has `aria-label="Breadcrumb"`.
- [ ] Landmark rotor on a detail page shows "Primary" and "Breadcrumb" — not two unlabelled "navigation" entries.
- [ ] `lint`, `tsc --noEmit`, and `build` pass locally.