### PR TITLE
fix(a11y,web): enlarge home page inline body link tap targets

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,7 +79,7 @@ export default function Home() {
                 href="https://www.enrichky.com/"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent underline decoration-accent/40 underline-offset-4 hover:decoration-accent"
+                className="inline-block py-0.5 text-accent underline decoration-accent/40 underline-offset-4 hover:decoration-accent"
               >
                 Enrich
               </a>
@@ -89,15 +89,18 @@ export default function Home() {
               volunteer-coordination app for community organizations). Most of this portfolio site
               was built by Shipyard, not by me.
             </p>
-            <p className="flex flex-wrap gap-x-6 gap-y-2 pt-2">
-              <Link href="/blog" className="text-accent underline-offset-4 hover:underline">
+            <div className="flex flex-wrap gap-x-6 gap-y-2 pt-2">
+              <Link
+                href="/blog"
+                className="inline-flex min-h-[44px] items-center text-accent underline-offset-4 hover:underline"
+              >
                 Read the blog →
               </Link>
               <a
                 href="https://github.com/mattsears18"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent underline-offset-4 hover:underline"
+                className="inline-flex min-h-[44px] items-center text-accent underline-offset-4 hover:underline"
               >
                 View on GitHub →
               </a>
@@ -105,11 +108,11 @@ export default function Home() {
                 href="https://www.linkedin.com/in/mattsears18/"
                 target="_blank"
                 rel="noreferrer"
-                className="text-accent underline-offset-4 hover:underline"
+                className="inline-flex min-h-[44px] items-center text-accent underline-offset-4 hover:underline"
               >
                 LinkedIn →
               </a>
-            </p>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
Closes #175

## Summary

Increases the tap-target hit area of the About-section action-row links on the home page (`app/page.tsx`). "Read the blog →", "View on GitHub →", and "LinkedIn →" now use the repo's established `inline-flex min-h-[44px] items-center` pattern (same as the site header/footer), bringing each to ≥ 44 px tall. The container `<p>` is now a `<div>` since the action row is a button-like row of flex children rather than prose. The mid-sentence "Enrich" inline link gets `inline-block py-0.5` to nudge its height toward the 24 px WCAG 2.5.8 minimum without breaking prose line flow.

No shared `.prose-post` rule was needed — the change is local to `app/page.tsx`.

## Test plan

- [ ] "Read the blog →", "View on GitHub →", "LinkedIn →" links report a tap-target height ≥ 44 px (`min-h-[44px]` + `items-center`).
- [ ] "Enrich" inline link gains vertical padding (`py-0.5`) toward the 24 px minimum while staying inline in its sentence.
- [ ] No visual regression to the prose layout (action row still wraps with `gap-x-6 gap-y-2`; `<div>` swap preserves spacing).
- [ ] `npm run lint`, `npx tsc --noEmit`, and `npm run build` pass locally.