### PR TITLE
fix(a11y,web): enlarge detail-page nav links to 44px tap target

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -69,7 +69,7 @@ export default async function PostPage({ params }: { params: Promise<Params> }) 
       <nav aria-label="Breadcrumb" className="mb-10">
         <Link
           href="/blog"
-          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          className="inline-flex min-h-[44px] items-center font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
         >
           ← Back to blog
         </Link>
@@ -91,7 +91,7 @@ export default async function PostPage({ params }: { params: Promise<Params> }) 
       <footer className="mt-20 border-t border-border pt-8">
         <Link
           href="/blog"
-          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          className="inline-flex min-h-[44px] items-center font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
         >
           All posts →
         </Link>

--- a/app/work/[slug]/page.tsx
+++ b/app/work/[slug]/page.tsx
@@ -83,7 +83,7 @@ export default async function ProjectPage({ params }: { params: Promise<Params> 
       <nav aria-label="Breadcrumb" className="mb-10">
         <Link
           href="/work"
-          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          className="inline-flex min-h-[44px] items-center font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
         >
           ← Back to work
         </Link>
@@ -137,7 +137,7 @@ export default async function ProjectPage({ params }: { params: Promise<Params> 
       <footer className="mt-20 border-t border-border pt-8">
         <Link
           href="/work"
-          className="font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
+          className="inline-flex min-h-[44px] items-center font-mono text-xs uppercase tracking-widest text-fg-muted hover:text-accent"
         >
           All work →
         </Link>


### PR DESCRIPTION
Closes #174

## Summary

The "← Back to work", "← Back to blog", "All work →", and "All posts →" navigation links on the `/work/[slug]` and `/blog/[slug]` detail pages rendered at ~16px tall — below the WCAG 2.5.8 (Target Size — Minimum) threshold. This applies the established `inline-flex min-h-[44px] items-center` pattern (already used in `app/components/site-header.tsx`, `app/components/site-footer.tsx`, `app/work/page.tsx`, and `app/page.tsx`) to all four detail-page nav links, giving them a 44px tap target.

The footer links in `SiteFooter` already carried the `min-h-[44px]` pattern, so no change was needed there.

## Test plan

- [ ] Breadcrumb back-links ("← Back to work" / "← Back to blog") now have a ≥44px click-target height.
- [ ] Footer nav links ("All work →" / "All posts →") now have a ≥44px click-target height.
- [ ] Fix applied to both `app/work/[slug]/page.tsx` and `app/blog/[slug]/page.tsx`.
- [ ] `npm run lint`, `npx tsc --noEmit`, and `npm run build` pass locally.