### PR TITLE
feat(test,ci): run Vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,8 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Test
+        run: npm test
+
       - name: Build
         run: npm run build


### PR DESCRIPTION
Closes #176

## Summary

CI previously ran `npm ci` → `lint` → `tsc --noEmit` → `build` but never executed the Vitest suite, so a broken assertion in `lib/posts.ts` / `lib/work.ts` could merge green. This adds a `Test` step (`npm test` → `vitest run`) to the `build` job in `.github/workflows/ci.yml`, between the type-check and build steps. Since the workflow already triggers on `pull_request` and `push` to `main`, no trigger change was needed.

The change is minimal and additive — no existing step was weakened or reordered. (The issue body mentioned removing duplicate `checkout`/`build` steps, but the current `ci.yml` has no duplicates — that description was stale, so there was nothing to remove.)

## Test plan

- [x] `npm test` passes locally (9 files, 73 tests green) after a clean `npm ci`
- [x] Verified the gate actually gates: temporarily injected a failing assertion into `lib/work.test.ts` → `vitest run` reported a failure (non-zero exit); reverted
- [x] `npm run lint` passes locally
- [ ] CI `Test` step runs and passes on this PR

## Out of scope (follow-up)

Acceptance criterion 3 (add the CI job to `main` branch protection's `required_status_checks`) is a repo-admin setting, not a code change in this diff — the issue body itself notes "enabling branch protection broadly is a release-readiness concern beyond this audit's lane." Once this PR's `Test` step is green, a maintainer can add the `ci / build` check as a required status check via repo settings. That step is intentionally left to a human with repo-admin access.