### PR TITLE
chore(security,ci): add npm-audit + CodeQL security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,46 @@
+name: security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 12 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: npm audit (high+)
+        run: npm audit --audit-level=high
+
+  codeql:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
Closes #45.

Adds `.github/workflows/security.yml` — `npm audit --audit-level=high` + CodeQL (javascript-typescript), on PR/push to main + a weekly schedule. The Dependabot half of #45 (`.github/dependabot.yml`) is already present on main, so this completes the issue.

This PR reuses the branch a prior session pushed (1 commit). Not auto-merging immediately — letting the new security workflow run on its own PR first, since `npm audit --audit-level=high` could legitimately fail and should be reviewed rather than admin-bypassed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)