### PR TITLE
chore(dx): add Claude Code Stop hook for tsc type-check gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,5 +11,19 @@
       "Bash(npx eslint:*)",
       "Bash(npx next:*)"
     ]
+  },
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx tsc --noEmit",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Closes #69

## Summary

Adds a `hooks.Stop` entry to `.claude/settings.json` that runs `npx tsc --noEmit` at the end of every assistant turn. This catches TypeScript errors in the working tree before a turn declares "done" — cheap insurance for a repo where Claude does most of the editing. The new `hooks` block is merged alongside the existing `permissions` block without clobbering it.

Matcher is `*` (every Stop event) with a 30s timeout ceiling. `tsc --noEmit` runs incrementally via the existing `tsconfig.tsbuildinfo` and completes in ~2s locally, well under the 10s budget the issue calls for.

## Test plan

- [x] Resulting `.claude/settings.json` is valid JSON (`jq empty` passes).
- [x] Existing `permissions.allow` block preserved (all 9 entries intact).
- [x] `hooks.Stop` runs `npx tsc --noEmit` with matcher `*`.
- [x] `npx tsc --noEmit` passes cleanly and completes in ~2s (under the 10s budget) on a fresh `npm ci`.