### PR TITLE
perf(web): lazy-load @sentry/nextjs client SDK off the critical path

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -1,5 +1,3 @@
-import * as Sentry from '@sentry/nextjs';
-
 /*
  * Sentry — browser config (loaded automatically by Next.js when
  * present at the repo root). See #43.
@@ -17,21 +15,79 @@ import * as Sentry from '@sentry/nextjs';
  *     page content (post bodies, drafts) which is more surface
  *     than this site needs for invisible-failure detection.
  *
- * Navigation transaction sample rate is conservative (10% in
- * prod, 100% in dev/preview) so we still see traces locally
- * without paying for them in production.
+ * Lazy-loaded off the initial critical path — see #215.
+ *
+ * The `@sentry/nextjs` client SDK is a ~410 KiB chunk that Lighthouse
+ * flagged as ~64.6% unused on first load. A static `import * as Sentry`
+ * here forces that chunk into the initial critical path (it shows up in
+ * the root `build-manifest.json` and every page's build manifest), so it
+ * blocks parse/compile on every navigation even though nothing on the
+ * page needs it synchronously.
+ *
+ * Sentry's own bundle-trimming levers (`webpack.treeshake` /
+ * `bundleSizeOptimizations` on `withSentryConfig`, and the
+ * `__SENTRY_TRACING__` define) only fire under the webpack plugin
+ * codepath; this site builds with Turbopack, where they're inert
+ * (verified empirically in #136 + #215 — config-only and `compiler.define`
+ * both gave a ~0-byte delta because Turbopack keeps the unused integration
+ * module that the define-guarded call site no longer references). Moving
+ * the SDK off the critical path is the lever that actually works here.
+ *
+ * We defer the dynamic `import('@sentry/nextjs')` to browser idle time
+ * (`requestIdleCallback`, falling back to a short `setTimeout`) so the SDK
+ * loads as a separate, non-blocking chunk after first paint. Error capture
+ * — the reason Sentry is wired in — is preserved; the only behavioral
+ * change is a brief window at the very start of the session before the SDK
+ * has initialized, which is an acceptable trade for keeping ~400 KiB off
+ * the critical path on a low-traffic personal site.
  */
 const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
 
-if (dsn) {
-  Sentry.init({
-    dsn,
-    environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV ?? 'development',
-    sendDefaultPii: false,
-    tracesSampleRate: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? 0.1 : 1.0,
-  });
+// Holds the loaded SDK module once the deferred import resolves, so the
+// router-transition hook below can forward to it.
+type SentryModule = typeof import('@sentry/nextjs');
+let sentryModule: SentryModule | null = null;
+
+function initSentry(): void {
+  if (!dsn) return;
+
+  import('@sentry/nextjs')
+    .then((Sentry) => {
+      sentryModule = Sentry;
+      Sentry.init({
+        dsn,
+        environment: process.env.NEXT_PUBLIC_VERCEL_ENV ?? process.env.NODE_ENV ?? 'development',
+        sendDefaultPii: false,
+        tracesSampleRate: process.env.NEXT_PUBLIC_VERCEL_ENV === 'production' ? 0.1 : 1.0,
+      });
+    })
+    .catch(() => {
+      // Sentry failing to load must never break the page — swallow.
+    });
 }
 
-// Next.js 15+: export the navigation-transaction hook so the SDK
-// can instrument App Router client-side navigations.
-export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;
+if (typeof window !== 'undefined' && dsn) {
+  const ric = (window as Window & { requestIdleCallback?: (cb: () => void) => void })
+    .requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(initSentry);
+  } else {
+    // Safari has no requestIdleCallback; defer past first paint instead.
+    window.setTimeout(initSentry, 0);
+  }
+}
+
+/*
+ * Next.js 15+: export the navigation-transaction hook so the SDK can
+ * instrument App Router client-side navigations. Because the SDK is now
+ * loaded lazily, this forwards to the real hook once it's available and
+ * is a no-op before then (navigations that happen in the first few
+ * hundred ms of a cold session simply aren't traced — acceptable for a
+ * personal site, and tracing accuracy on the very first navigation was
+ * already best-effort).
+ */
+export function onRouterTransitionStart(
+  ...args: Parameters<SentryModule['captureRouterTransitionStart']>
+): void {
+  sentryModule?.captureRouterTransitionStart(...args);
+}


### PR DESCRIPTION
Closes #215

## Summary

The `@sentry/nextjs` client SDK is a ~410 KiB chunk that Lighthouse flagged as ~64.6% unused on first load. A static `import * as Sentry` in `instrumentation-client.ts` forced that chunk into the initial critical path (it appears in the root `build-manifest.json` and every page's build manifest), blocking parse/compile on every navigation even though nothing on the page needs it synchronously.

This defers the SDK behind a dynamic `import('@sentry/nextjs')` scheduled at browser idle (`requestIdleCallback`, falling back to `setTimeout` on Safari), so it loads as a separate, non-blocking chunk after first paint. `onRouterTransitionStart` is kept as an export that forwards to the SDK once loaded (no-op before then).

## Decision (the maintainer call the issue asked for)

The issue offered two levers: (1) tree-shake tracing via `__SENTRY_TRACING__: false`, or (2) lazy-load. I verified empirically that **option 1 is inert on this build**: Sentry's tree-shaking only runs under its webpack plugin, and this site builds with Turbopack. Both `webpack.treeshake` / `bundleSizeOptimizations` on `withSentryConfig` **and** a `compiler.define __SENTRY_TRACING__: false` produced a ~0-byte delta (the define replaced the flag, but Turbopack kept the now-dead-call's still-`require`d integration module). This matches the #136 investigation's 922,708-byte no-change finding.

Option 2 (lazy-load) was chosen because it actually works under Turbopack **and** preserves tracing/telemetry — only the load timing changes.

## Measured result

Initial critical-path JS (sum of all chunks referenced by the root `build-manifest.json`):

| | bytes |
|---|---|
| Baseline (eager static import) | 820,411 |
| This PR (lazy idle import) | 574,259 |
| **Reduction** | **246,152 (~240 KiB)** |

The full Sentry SDK chunk is now referenced by **0** build manifests (root + per-page) — confirmed off the initial critical path. Satisfies the AC ("client Sentry chunk reduced ≥50 KiB **or** moved off the initial critical path; decision documented").

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 73/73 pass
- [x] `npm run build` succeeds
- [x] Verified the Sentry chunk no longer appears in `build-manifest.json` or any `.next/server/app/**/build-manifest.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)