### PR TITLE
content(blog): drop explicit coworker-pitch framing from shipyard post

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -162,8 +162,8 @@ myself. Even doubled, it's a striking number against 500+ merged PRs.
 
 ## The honest caveats
 
-I want coworkers to try this, so I'm going to be straight about where it
-hurts:
+If any of the above has you tempted to try it, you should know where it
+hurts first:
 
 - **It's experimental.** The README opens with a warning box, and it's
   earned. Safety comes from prompt discipline and layered guardrails — issue
@@ -187,7 +187,7 @@ hurts:
 
 ## Why I'm writing this up
 
-Because the pattern generalizes, and I'd like to try it where I work. The
+Because the pattern generalizes well beyond a solo project. The
 unit of coordination is just a GitHub issue — which means the intake side
 (Sentry, Dependabot, support tooling, audits, humans) and the review side
 (branch protection, CODEOWNERS, required reviews) are things every team


### PR DESCRIPTION
Rewords two lines in the shipyard/lightwork post so it no longer explicitly states the "I want coworkers to try this / I'd like to try it where I work" motivation — the caveats intro and the "Why I'm writing this up" opener. Content-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)