### PR TITLE
content(blog): link lightwork to getlightwork.com, not the private repo

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -12,7 +12,7 @@ tags:
 ---
 
 For the last ten weeks I've been working on two projects at once. The first is
-[Lightwork](https://github.com/mattsears18/lightwork), a volunteer task
+[Lightwork](https://getlightwork.com), a volunteer task
 management app — Expo (React Native) + Firebase, shipping to iOS, Android, and
 the web. The second is [Shipyard](https://github.com/mattsears18/shipyard), a
 Claude Code plugin that turns a GitHub issue backlog into merged pull requests
@@ -194,11 +194,11 @@ unit of coordination is just a GitHub issue — which means the intake side
 already has. Shipyard slots into the middle and burns down the well-specified
 work, while the humans keep every decision that actually needs one.
 
-If you want to poke at it, both repos are public:
-[mattsears18/shipyard](https://github.com/mattsears18/shipyard) (the plugin —
-the closed PRs labeled `shipyard` are the living demo) and
-[mattsears18/lightwork](https://github.com/mattsears18/lightwork) (the app it
-helped build). Installing it is two commands:
+If you want to poke at it, the shipyard repo is public at
+[mattsears18/shipyard](https://github.com/mattsears18/shipyard) — the closed
+PRs labeled `shipyard` are the living demo — and the app it helped build
+lives at [getlightwork.com](https://getlightwork.com). Installing the plugin
+is two commands:
 
 ```sh
 claude plugin marketplace add mattsears18/shipyard


### PR DESCRIPTION
The lightwork repo is private, so the shipyard post's links to github.com/mattsears18/lightwork would 404 for readers. Both links now point to https://getlightwork.com (verified live, 200), and the "both repos are public" sentence is reworded since only shipyard's repo is public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)