### PR TITLE
content(blog): add FlutterFlow friction to the prototype story

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -95,10 +95,14 @@ localization. One codebase for iOS, Android, and a PWA.
 Lightwork didn't start in React Native. The first version was about four
 months of work in [FlutterFlow](https://flutterflow.io) — a low-code
 platform where you build cross-platform apps visually instead of writing
-them by hand. I built a lot of real features there, but the prototype never
-quite reached the point where I could ship it. In April 2026 I started over
-in React Native, and the first task I completed was porting that FlutterFlow
-prototype into the new codebase.
+them by hand. I picked it because low-code was supposed to be the fast way
+to build an app. I built a lot of real features there, but the developer
+experience was atrocious: I had no way to write any meaningful tests, and
+too much of what FlutterFlow did was a black box — I didn't fully
+understand how it worked, and I didn't have full control over what it was
+doing. The prototype never quite reached the point where I could ship it.
+In April 2026 I started over in React Native, and the first task I
+completed was porting that FlutterFlow prototype into the new codebase.
 
 Ten weeks later, the repo is at **1,671 commits**, version 2.51.0, and
 roughly **153,000 lines of TypeScript** — about 80k of app code and 73k of


### PR DESCRIPTION
Expands the FlutterFlow paragraph per feedback: low-code was chosen as the supposedly fast path, but the DX was atrocious — no meaningful tests possible, black-box behavior, incomplete control — which is why the prototype never shipped. Also quietly sets up the later contrast with the 3,000+ tests shipyard wrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)