### PR TITLE
content(blog): production errors patched within minutes, not hours

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -172,7 +172,7 @@ the GitHub repo, and Crashlytics watches the mobile apps — when either one
 catches an error or a crash, it automatically opens an issue, stack trace
 and all. From there the issue rides the same loop as everything else:
 refined, investigated, dispatched, fixed, merged. An error that surfaces in
-production can be patched within hours of the first time it fires, without
+production can be patched within minutes of the first time it fires, without
 anyone triaging a dashboard first.
 
 Users feed the loop too. The app has a feedback form, and submissions flow


### PR DESCRIPTION
One-word correction in the self-healing section per feedback: "within minutes of the first time it fires," not hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)