### PR TITLE
content(blog): cold open audits both the live app and the codebase

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -14,13 +14,18 @@ tags:
 
 import { LightboxImage } from '@/app/components/lightbox-image';
 
-On the morning of June 4th I typed one command into a terminal. It audited my
-app — accessibility, SEO, privacy, security, docs, a dozen other dimensions —
-and filed **64 GitHub issues**, each one labeled, severity-ranked, and
-written like a competent engineer's bug report. The skip-navigation link
-missing from the authenticated app shell. Tap targets two pixels under
-Apple's 44-point floor. A cookie-consent link that wasn't
-keyboard-activatable.
+On the morning of June 4th I typed one command into a terminal. It audited
+lightwork from both ends — browser-level passes over the live, deployed app
+(accessibility, SEO, privacy, performance) and code-level passes over the
+repository behind it (testing gaps, tech debt, observability, API surface,
+docs drift) — and filed **64 GitHub issues**, each one labeled,
+severity-ranked, and written like a competent engineer's bug report. From
+the live app: a skip-navigation link missing from the authenticated shell,
+tap targets two pixels under Apple's 44-point floor, a cookie-consent link
+that wasn't keyboard-activatable. From the codebase: four user-scoped
+Firestore list subscriptions with no row cap, client error handlers that
+logged failures to the console but never reported them to Sentry, a README
+stack section that had drifted out of date.
 
 That evening I typed one more command and went on with my night. Between
 9:13 and 10:33 PM, **thirteen pull requests merged** — each one written by


### PR DESCRIPTION
Per feedback: the opening now states the audit covered both the live deployed app (browser-level: a11y, SEO, privacy, performance) and the codebase (testing gaps, tech debt, observability, API surface, docs drift), and adds engineer-relevant codebase examples pulled from the real June 4 run — uncapped Firestore list subscriptions, console-only error handlers never reaching Sentry, README stack drift (lightwork issues #1680, #1684, #1691).

🤖 Generated with [Claude Code](https://claude.com/claude-code)