### PR TITLE
content(blog): drop side-project aside from the cold open

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -33,8 +33,7 @@ an autonomous worker in its own git worktree, each one closing one of the
 morning's issues, each one merged by CI without me touching the keyboard.
 The skip-link fix merged 26 minutes after its PR opened.
 
-I didn't write a line of any of them. And this isn't my job — it's a side
-project, worked on nights and weekends. This post is about how an ordinary
+I didn't write a line of any of them. This post is about how an ordinary
 Thursday evening got to look like that — because the machinery behind it is
 the most leverage I've ever gotten out of a tool I built.
 


### PR DESCRIPTION
Removes "And this isn't my job — it's a side project, worked on nights and weekends." from the cold open, per feedback. The side-project framing remains in the excerpt, the intro section, and the ten-weeks passage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)