### PR TITLE
content(blog): cite merged PRs instead of commit count

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -125,11 +125,12 @@ doing. The prototype never quite reached the point where I could ship it.
 In April 2026 I started over in React Native, and the first task I
 completed was porting that FlutterFlow prototype into the new codebase.
 
-Ten weeks of nights and weekends later, the repo is at **1,671 commits**,
-version 2.51.0, and roughly **153,000 lines of TypeScript** — about 80k of
-app code and 73k of tests — working through the App Store and Play Store
-launch checklists. Four months of low-code got me a prototype; ten weeks of
-spare hours with this setup got me to launch prep. One person, after hours.
+Ten weeks of nights and weekends later, the repo has **1,016 merged pull
+requests**, sits at version 2.51.0, and holds roughly **153,000 lines of
+TypeScript** — about 80k of app code and 73k of tests — working through the
+App Store and Play Store launch checklists. Four months of low-code got me
+a prototype; ten weeks of spare hours with this setup got me to launch
+prep. One person, after hours.
 
 The difference was Claude Code — and, very quickly, what I learned about
 where its real constraint is. An agent session is brilliant at writing code


### PR DESCRIPTION
Per feedback: the ten-weeks stats line now leads with 1,016 merged pull requests instead of the commit count. (The 1,016 figure already appears in The Numbers section — it's the verified merged-PR total for the repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)