### PR TITLE
content(blog): drop the attribution-caveat paragraph

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -278,13 +278,6 @@ the lightwork repo's merge cadence over the past six weeks:
 
 ![Bar chart of merged PRs per week in the lightwork repo, May 4 through June 11. Weekly totals: 17, 263, 354, 161, 175, and 30 in the partial final week](/blog/shipyard-lightwork/lightwork-prs-per-week.svg)
 
-One honest note on attribution: the `shipyard` label that stamps every
-orchestrator-opened PR didn't exist until May 18 — shipyard was already
-doing work before its label was — so I can't cleanly split that chart into
-"the machine's PRs" and "mine," and I won't pretend to. What the label does
-establish: since May 18, **524 merged PRs were opened end-to-end by shipyard
-workers**. Treat that number as a floor, not a census.
-
 The totals so far:
 
 - **Lightwork:** 1,016 merged PRs, 839 issues closed, and over 300 of the


### PR DESCRIPTION
Per feedback, removes the "One honest note on attribution" paragraph from The Numbers section. The chart now flows directly into the totals list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)