### PR TITLE
content(blog): /my-turn as step 4 + the self-sharpening flywheel

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -146,7 +146,7 @@ The constraint wasn't the model. It was me.
 Shipyard is an engineering loop — find work → refine it → do it → merge it →
 repeat — packaged as a
 [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin so the
-loop runs without a human driving each step. It does three things:
+loop runs without a human driving each step. It does four things:
 
 ![Shipyard: audits, third-party services, user feedback, and manual entry feed an issue backlog; an orchestrator dispatches issue workers that ship the work](/blog/shipyard-lightwork/shipyard-marketing.jpg)
 
@@ -168,6 +168,12 @@ loop runs without a human driving each step. It does three things:
    Green CI means it merges itself and the next worker dispatches. When CI
    breaks — on a PR, or on main itself — the orchestrator diverts a worker to
    fix that first.
+4. **It tells me when it's my turn.** `/my-turn` is the human-facing
+   counterpart to `/do-work`: it surveys the open PRs, the backlog, and
+   recent comments, and hands back a short, prioritized list of exactly the
+   items that are blocked on _me_ rather than on the machine — sign-offs,
+   judgment calls, stuck work. The other three commands take work off my
+   plate; this one tells me precisely what belongs on it.
 
 ![Shipyard at a glance: five stages from issue sources through refinement and human review, into the orchestrator, out to parallel workers in isolated worktrees, and into the PR pipeline with auto-merge](/blog/shipyard-lightwork/shipyard-infographic.svg)
 
@@ -210,6 +216,21 @@ captures the reporter's email address, so notifying someone when their
 report ships — "the bug you filed on Tuesday was fixed on Wednesday" — is
 one small automation away. A feedback form that answers you back.
 
+### Shipyard builds shipyard
+
+The strangest loop points back at itself: **shipyard is built with
+shipyard.** The vast majority of its own merged PRs were opened by its own
+workers (the numbers are below). But the flywheel is the part I didn't
+plan: when a `/do-work` run on lightwork hits friction — a worker misreads
+an ambiguous contract, the orchestrator mishandles an edge case, a helper
+script returns the wrong thing — that friction is **automatically filed as
+an issue against the shipyard repo**. The next `/do-work` run on shipyard
+burns those issues down. Friction encountered building my app becomes the
+spec for improving the tool, and the improved tool builds the app better.
+Dogfooding is eating what you cook; this is closer to a **self-sharpening
+tool** — every rough edge it hits while building lightwork makes it a
+little better at building everything else.
+
 ### Where the human fits in the loop
 
 It's an autonomous loop, not an unsupervised one — the division of labor is
@@ -229,11 +250,11 @@ design calls, sign off on anything derived from real user feedback, review
 the PRs where correctness has real stakes, and unstick the work it hands
 back as `blocked`.
 
-And the loop closes in both directions: `/my-turn` surveys the open PRs, the
-backlog, and recent comments, and produces a prioritized list of exactly the
-items that are blocked on _me_ rather than on the machine — the read-only,
-human-facing counterpart to `/do-work`. I gate what it builds; it tells me
-where I'm the bottleneck.
+And that hand-off has its own command — `/my-turn`, step 4 above. After a
+day of the machine working, it's how I find out what the loop actually
+needs from a human, in priority order, instead of trawling GitHub trying
+to reconstruct it myself. The division of labor in one line: I gate what
+it builds; it tells me where I'm the bottleneck.
 
 ## It built the platform, not just the patches
 


### PR DESCRIPTION
Per feedback:

- **`/my-turn` gets step-4 billing** in the "It does four things" list — "The other three commands take work off my plate; this one tells me precisely what belongs on it." The human-in-the-loop closing paragraph now references step 4 instead of re-explaining the command, keeping the emphasis without duplication.
- **New "Shipyard builds shipyard" subsection**: friction from lightwork `/do-work` runs is automatically filed as issues against the shipyard repo; running `/do-work` on shipyard burns them down. Buzzword framing: "Dogfooding is eating what you cook; this is closer to a **self-sharpening tool**."

🤖 Generated with [Claude Code](https://claude.com/claude-code)