### PR TITLE
content(blog): asking/giving-help description + all site PRs are shipyard's

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -53,7 +53,8 @@ For the last ten weeks I've been working on two projects at once — both
 **passion projects**, built in the hours around everything else. None of
 this is the output of full-time work; it's what nights and weekends
 produced. The first is
-[Lightwork](https://getlightwork.com), a volunteer task management app —
+[Lightwork](https://getlightwork.com), an app for asking your community
+for help and volunteering to give it —
 Expo (React Native) + Firebase, shipping to iOS, Android, and the web. The
 second is [Shipyard](https://github.com/mattsears18/shipyard), an
 **autonomous engineering loop** built on Claude Code: it finds work, refines
@@ -65,22 +66,27 @@ shipyard because I was the bottleneck in building lightwork.**
 
 ## The app, and the four months that didn't ship
 
-Lightwork is the product. Users join groups (a church, a neighborhood
-association, a mutual-aid crew), post tasks that need volunteers — with
-locations, schedules, and recurring series — and sign up to help. Real-time
-data on Firestore, group search via Algolia, maps, per-task messaging,
-localization. One codebase for iOS, Android, and a PWA.
+Lightwork is the product: an app for asking for help, and for showing up
+to give it. You join the groups already in your life — a church, a
+neighborhood association, a school parent group — and when you need a
+hand, you ask: a ride to the airport, cookies for the hospital staff,
+gloves and a water bottle at the park on Saturday. Asks can be one-time or
+recurring, public or group-only, and they land on a map of your area, so
+neighbors can see who needs a hand nearby, volunteer with a tap, and
+coordinate in a per-request chat. Real-time data on Firestore, group
+search via Algolia, localization, one codebase for iOS, Android, and a
+PWA.
 
 <ImageCarousel
   label="Lightwork app screenshots"
   slides={[
     {
       src: '/blog/shipyard-lightwork/carousel-01-home.jpg',
-      alt: 'Lightwork home feed of volunteer tasks, captioned: Help asked plainly. Help given freely.',
+      alt: 'Lightwork home feed of asks for help, captioned: Help asked plainly. Help given freely.',
     },
     {
       src: '/blog/shipyard-lightwork/carousel-02-map.jpg',
-      alt: 'Lightwork map of nearby task locations, captioned: See who needs a hand near you.',
+      alt: 'Lightwork map of nearby asks for help, captioned: See who needs a hand near you.',
     },
     {
       src: '/blog/shipyard-lightwork/carousel-groups.jpg',
@@ -96,11 +102,11 @@ localization. One codebase for iOS, Android, and a PWA.
     },
     {
       src: '/blog/shipyard-lightwork/carousel-04-chat.jpg',
-      alt: 'Lightwork per-task message thread, captioned: Chat in real time on every request.',
+      alt: 'Lightwork per-request message thread, captioned: Chat in real time on every request.',
     },
     {
       src: '/blog/shipyard-lightwork/carousel-05-detail.jpg',
-      alt: 'Lightwork task detail with volunteer signup, captioned: Show up. Make it count.',
+      alt: 'Lightwork request detail with volunteer signup, captioned: Show up. Make it count.',
     },
     {
       src: '/blog/shipyard-lightwork/carousel-profile.jpg',
@@ -300,8 +306,8 @@ that sentence.
 And one more, since you're looking at it: **shipyard built this site.**
 When I wanted somewhere to publish this post, shipyard rebuilt my personal
 site from the ground up — Next.js, the design system, RSS, the SEO and
-accessibility plumbing — and had it live in a day. Of the 135 pull requests
-merged into the site's repo, 91 were opened by shipyard workers.
+accessibility plumbing — and had it live in a day. Every pull request ever
+merged into the site's repo was opened by shipyard.
 
 ## The numbers
 


### PR DESCRIPTION
Per feedback:

- **App description rewritten** in the screenshots' own language: "an app for asking for help, and for showing up to give it" — joining the groups already in your life, concrete asks (a ride to the airport, cookies for the hospital staff), one-time or recurring, public or group-only, on a map, volunteer with a tap, per-request chat. No more "posting tasks." The intro descriptor and four carousel alt texts updated to match.
- **Site proof point corrected**: every PR ever merged into this repo was opened by shipyard — the previous 91-of-135 figure reflected label coverage, not authorship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)