### PR TITLE
content(blog): updated app description + screenshot-pipeline note

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -68,14 +68,14 @@ shipyard because I was the bottleneck in building lightwork.**
 
 Lightwork is the product: an app for asking for help, and for showing up
 to give it. You join the groups already in your life — a church, a
-neighborhood association, a school parent group — and when you need a
-hand, you ask: a ride to the airport, cookies for the hospital staff,
-gloves and a water bottle at the park on Saturday. Asks can be one-time or
-recurring, public or group-only, and they land on a map of your area, so
+neighborhood association, a school parent group — or not, and when you
+need a hand, you ask: a ride to the airport, cookies for the hospital
+staff, gloves and a water bottle at the park on Saturday. Asks can be
+one-time or recurring, public or group-only, and they land on a map, so
 neighbors can see who needs a hand nearby, volunteer with a tap, and
-coordinate in a per-request chat. Real-time data on Firestore, group
-search via Algolia, localization, one codebase for iOS, Android, and a
-PWA.
+coordinate in a per-request chat. Real-time data on Firestore, offline
+support, push notifications, search via Algolia, social OAuth,
+localization, one codebase for iOS, Android, and a PWA.
 
 <ImageCarousel
   label="Lightwork app screenshots"
@@ -114,6 +114,12 @@ PWA.
     },
   ]}
 />
+
+The screenshots above are shipyard's work too: it built the pipeline that
+seeds demo data, drives the app screen by screen, and composes the
+captioned, store-ready images — the same set submitted to the App Store
+and Google Play. Somewhere in the backlog is the next step: a demo video
+of the app, generated the same way, for the store listings.
 
 Lightwork didn't start in React Native. The first version was about four
 months of work in [FlutterFlow](https://flutterflow.io) — a low-code


### PR DESCRIPTION
Per feedback:

- The lightwork description paragraph is replaced with the supplied rewording — groups now optional ("or not"), map phrasing simplified, and the stack list expanded (offline support, push notifications, social OAuth).
- New paragraph after the carousel: the screenshots themselves are shipyard's work (it built the pipeline that seeds demo data, drives the app, and composes the captioned store-ready images — the same set submitted to the stores), and a store-listing demo video generated the same way is the next step in the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)