### PR TITLE
content(blog): name Lightwork in the feedback-form sentence

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -216,7 +216,7 @@ refined, investigated, dispatched, fixed, merged. An error that surfaces in
 production _can be_ patched within minutes of the first time it fires, without
 anyone triaging a dashboard first.
 
-Users feed the loop too. The app has a feedback form, and submissions flow
+Users feed the loop too. Lightwork has a feedback form, and submissions flow
 straight into the issue backlog — feature requests, bug reports, all of it.
 In effect, the public can file issues against the repo: anyone using the
 app can put a request in front of shipyard. But that lane has guardrails.


### PR DESCRIPTION
Per feedback: "Lightwork has a feedback form" instead of "The app has a feedback form."

🤖 Generated with [Claude Code](https://claude.com/claude-code)