### PR TITLE
feat(content): open external MDX links in a new tab

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -77,10 +77,23 @@ function CodeBlockPre(props: ComponentPropsWithoutRef<'pre'>) {
   return <pre {...props} aria-label={existingAriaLabel ?? ariaLabel} />;
 }
 
+/*
+ * Open off-site links in a new tab, matching the convention the site
+ * chrome already follows (footer GitHub link, work-page external links).
+ * Internal/relative links keep default navigation so readers don't lose
+ * back-button behavior inside the site.
+ */
+function ContentLink(props: ComponentPropsWithoutRef<'a'>) {
+  const isExternal = typeof props.href === 'string' && /^https?:\/\//.test(props.href);
+  if (!isExternal) return <a {...props} />;
+  return <a {...props} target="_blank" rel="noopener noreferrer" />;
+}
+
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...components,
     pre: CodeBlockPre,
+    a: ContentLink,
     /*
      * Every MDX image — markdown `![]()` and author-written `<img>` alike —
      * opens fullsize in a lightbox on tap/click (#231).


### PR DESCRIPTION
Adds an `a` mapping in `mdx-components.tsx`: off-site (http/https) links get `target="_blank"` + `rel="noopener noreferrer"`; internal links are untouched. Verified against the production build — all 7 external anchors in the shipyard post carry the attributes, matching the existing site-chrome convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)