### PR TITLE
content(blog): quantify the GitHub Actions side of the cost story

### DIFF
--- a/content/posts/shipyard-and-lightwork.mdx
+++ b/content/posts/shipyard-and-lightwork.mdx
@@ -375,6 +375,13 @@ counts, so that's an undercount; and it excludes the interactive Claude
 Code sessions I drove myself. Even doubled, it's a striking number set
 against everything described above.
 
+Tokens aren't the whole bill, though. Lightwork's CI has logged nearly
+14,000 workflow runs, and back-of-envelope math from the run logs puts
+that at roughly **80,000 GitHub Actions minutes** — call it another ~$650
+at list price. That's the real cost shape of an autonomous loop: tokens to
+write the code, CI minutes to prove it — and proving it cost more than
+writing it.
+
 ## The honest caveats
 
 If that Tuesday has you tempted, you should know where it hurts first:


### PR DESCRIPTION
Closes out the last open item from the principal-engineer review: the cost paragraph counted tokens but never quantified CI minutes.

**Methodology** (estimate, hedged as back-of-envelope in the post): sampled 105 workflow runs spread across lightwork's 13,761-run history, summed per-job durations via the Actions API (the billable field is deprecated and returns empty), got a mean of 5.95 job-minutes/run → ~82,000 Linux minutes → ~$650 at the $0.008/min list rate, before any plan-included free minutes.

New copy: "Tokens aren't the whole bill, though... roughly **80,000 GitHub Actions minutes** — call it another ~$650 at list price. That's the real cost shape of an autonomous loop: tokens to write the code, CI minutes to prove it — and proving it cost more than writing it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)